### PR TITLE
Fix four HIGH findings from the v0.3.0 review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,45 @@ changes when they are called out here with a migration note.
 
 ## [Unreleased]
 
+### Fixed
+
+- Acceptance now enforces the documented requirement that excluded generated
+  files be removed first. Excluded paths are deliberately outside the
+  fingerprint, so they never made the worktree dirty and `ensure_clean` let a
+  candidate through while they were still present. That allowed a ChangeSet to
+  be accepted whose validation may have depended on content absent from the
+  accepted commit, which is exactly what the fingerprint exists to prevent.
+  Removing the files cannot invalidate the ChangeSet, because their presence
+  and content were excluded from the fingerprint to begin with.
+- Migration now runs in a single immediate transaction. An interrupted upgrade
+  previously left the `intent_scopes` projection partially written, and the
+  per-intent skip guard then treated the partial intent as done forever, so the
+  intent silently disappeared from scope queries with no error. The migration is
+  now all or nothing, and schema 3 reprojects every intent once to repair stores
+  already damaged this way.
+- One-time backfills are gated on the stored schema version instead of running
+  on every `Store::open`. Schema 2 re-ran them on every process start, which
+  minted a duplicate synthesized detection for every conflict that already had a
+  native one: two immutable observations for a single detection, and an
+  occurrence table that disagreed with the event log. Schema 3 removes those
+  duplicates on first open, keeping genuine legacy rows where they are a
+  conflict's only observation. Gating also removes a full rescan of `intents`,
+  `conflicts`, and `validations` from every CLI invocation.
+- `PRAGMA recursive_triggers` is enabled so the append-only triggers on
+  `validation_attempts`, `conflict_detections`, and `events` also fire for the
+  implicit delete inside an `INSERT OR REPLACE`, which previously bypassed them.
+- The documented daemon shutdown grace is now a process-exit bound. The daemon
+  builds and owns its Tokio runtime, so when the 30 second HTTP grace expires it
+  abandons the remaining requests (terminating the validation subprocess trees
+  it started), waits at most 5 further seconds for blocking work that cannot be
+  cancelled, and then exits: 0 after a clean drain, 1 when the bound had to be
+  enforced. Previously the runtime was dropped at the end of `main`, which
+  blocked forever on an uncancellable blocking task such as a wedged `git`
+  child, leaving the daemon alive and swallowing later signals. Documentation
+  now also states what still survives the forced exit: a child process started
+  outside a validation guard is not killed, and signals sent during the drain
+  are ignored.
+
 ## [0.3.0] - 2026-08-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ changes when they are called out here with a migration note.
 
 ### Fixed
 
+- Validation now refuses to start when excluded generated files are already
+  present. Exclusions exist so a check may create such files without
+  invalidating its own fingerprint; a file that exists beforehand is different,
+  because the command may consume it, and a pass could then depend on content
+  absent from the candidate commit and uncovered by the fingerprint. Requiring a
+  clean start means every excluded path seen afterwards was produced by that
+  run. Migration: delete generated artifacts between validations.
 - Acceptance now enforces the documented requirement that excluded generated
   files be removed first. Excluded paths are deliberately outside the
   fingerprint, so they never made the worktree dirty and `ensure_clean` let a
@@ -33,9 +40,20 @@ changes when they are called out here with a migration note.
   duplicates on first open, keeping genuine legacy rows where they are a
   conflict's only observation. Gating also removes a full rescan of `intents`,
   `conflicts`, and `validations` from every CLI invocation.
-- `PRAGMA recursive_triggers` is enabled so the append-only triggers on
-  `validation_attempts`, `conflict_detections`, and `events` also fire for the
-  implicit delete inside an `INSERT OR REPLACE`, which previously bypassed them.
+- Reusing the id of an existing `validation_attempts` or `conflict_detections`
+  row is rejected by the schema itself. `INSERT OR REPLACE` deletes the
+  conflicting row first, and that delete only fires the append-only trigger when
+  `recursive_triggers` is on, which is a per-connection setting that any other
+  SQLite client can ignore. `PRAGMA recursive_triggers` is now enabled as
+  defense in depth rather than as the guarantee.
+- The schema version is parsed strictly and a store newer than the running build
+  is refused with `UNSUPPORTED_SCHEMA` instead of being migrated backwards and
+  restamped. A malformed value is reported as `CORRUPT_STORE` rather than
+  silently reading as zero, which would have rerun every one-time backfill.
+- The schema 3 repair removes only a byte-identical duplicate observation. The
+  previous condition deleted any synthesized row whenever a native one existed
+  for the same conflict, which destroyed a genuine earlier observation that a
+  later redetection happened to follow.
 - The documented daemon shutdown grace is now a process-exit bound. The daemon
   builds and owns its Tokio runtime, so when the 30 second HTTP grace expires it
   abandons the remaining requests (terminating the validation subprocess trees

--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ curl --fail --silent --show-error \
 
 Do not print, commit, or share the token. `/healthz` is database-free process
 liveness and `/readyz` is a bounded non-waiting store probe; both are public.
-Every `/v1` route—including paged event-chain audit—requires the token unless
+Every `/v1` route, including the paged event-chain audit, requires the token unless
 the daemon was deliberately started with `--no-auth` for a trusted local test.
 The MVP refuses non-loopback binds and is not a hardened multi-tenant service.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -173,7 +173,11 @@ full event-chain audit is authenticated and paged through a separate read-only
 connection. Synchronous SQLite and Git service calls are dispatched with
 `spawn_blocking` so they do not occupy Tokio worker threads. SIGINT/SIGTERM stop
 new HTTP work and bound in-flight draining to 30 seconds; validation cancellation
-terminates the subprocess tree.
+terminates the subprocess tree. The daemon owns its own Tokio runtime so the
+bound is a process-exit bound: when the grace expires it abandons the remaining
+requests, gives uncancellable blocking work 5 further seconds, and exits 1
+(a clean drain exits 0). A child process started outside a validation guard, for
+example a wedged `git` call, is not killed and may outlive the daemon.
 
 ## Trust and safety boundaries
 

--- a/docs/json-api.md
+++ b/docs/json-api.md
@@ -499,6 +499,23 @@ MVP API does not promise general HTTP idempotency keys. Generated IDs and the
 append-only event log make duplicate semantic actions visible, but clients
 should not assume a repeated POST is deduplicated.
 
+### Shutdown
+
 On SIGINT or SIGTERM the daemon stops accepting new connections and gives
-in-flight operations, including validation, up to 30 seconds to finish. After
-that bound it terminates remaining requests and their validation process trees.
+in-flight operations, including validation, up to 30 seconds to finish. If the
+drain completes the daemon exits 0.
+
+If the grace expires with requests still in flight, the daemon does not wait for
+them. It abandons the remaining request futures (which terminates the validation
+subprocess trees Foremerge started itself), then allows up to 5 more seconds for
+blocking work that cannot be cancelled, and then exits 1. The process therefore
+exits within roughly 35 seconds of the signal.
+
+Two things survive that forced exit:
+
+- A child process Foremerge did not start under a validation guard, such as a
+  wedged `git` invocation inside a request, is not killed and can outlive the
+  daemon. Foremerge stops waiting for it; it does not reap it.
+- Further signals sent during the drain are ignored. The first SIGINT or SIGTERM
+  starts the bounded sequence above and the daemon exits on its own; SIGKILL is
+  the only way to end it sooner.

--- a/src/api.rs
+++ b/src/api.rs
@@ -12,12 +12,41 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
-use std::future::IntoFuture;
+use std::future::{Future, IntoFuture};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
 const SHUTDOWN_GRACE: Duration = Duration::from_secs(30);
+
+/// Bounded wait for the Tokio runtime once `serve` has returned. Dropping the
+/// runtime cancels pending request futures, which runs the validation
+/// cancellation guards, but it cannot cancel a blocking task that is already
+/// inside a synchronous child process. The caller uses this bound so a wedged
+/// child cannot hold the process open forever.
+pub const RUNTIME_SHUTDOWN_GRACE: Duration = Duration::from_secs(5);
+
+/// How the HTTP server stopped, so the caller can decide how the process exits.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShutdownOutcome {
+    /// Every in-flight request finished inside the grace period.
+    Drained,
+    /// The grace expired with requests still in flight; the remaining request
+    /// futures were abandoned rather than awaited.
+    GraceExpired,
+}
+
+impl ShutdownOutcome {
+    /// The shutdown bound had to be enforced rather than observed.
+    pub fn grace_expired(self) -> bool {
+        matches!(self, Self::GraceExpired)
+    }
+}
+
+/// The grace applied to in-flight HTTP work after SIGINT or SIGTERM.
+pub fn shutdown_grace() -> Duration {
+    SHUTDOWN_GRACE
+}
 
 #[derive(Clone)]
 pub struct ApiState {
@@ -211,30 +240,64 @@ async fn authenticate(
     Ok(next.run(request).await)
 }
 
-pub async fn serve(state: ApiState, bind: SocketAddr) -> anyhow::Result<()> {
+/// Serve the loopback JSON API until SIGINT or SIGTERM, then drain.
+///
+/// The returned outcome reports whether the drain completed or the grace had to
+/// be enforced. A `GraceExpired` outcome means abandoned request futures may
+/// still be attached to the runtime, so the caller must shut the runtime down
+/// under [`RUNTIME_SHUTDOWN_GRACE`] and then exit the process deliberately.
+pub async fn serve(state: ApiState, bind: SocketAddr) -> anyhow::Result<ShutdownOutcome> {
     let listener = tokio::net::TcpListener::bind(bind).await?;
     tracing::info!(%bind, "Foremerge API listening");
+    serve_with_shutdown(listener, router(state), SHUTDOWN_GRACE, shutdown_signal()).await
+}
+
+/// Shared shutdown mechanics for [`serve`], with the listener, router, grace,
+/// and shutdown trigger injected so the bound itself is testable.
+async fn serve_with_shutdown<F>(
+    listener: tokio::net::TcpListener,
+    router: Router,
+    grace: Duration,
+    shutdown: F,
+) -> anyhow::Result<ShutdownOutcome>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
     let draining = Arc::new(tokio::sync::Notify::new());
-    let server = axum::serve(listener, router(state))
-        .with_graceful_shutdown(shutdown_signal(draining.clone()))
+    let notify = draining.clone();
+    let graceful = async move {
+        shutdown.await;
+        tracing::info!("shutdown requested; draining in-flight requests");
+        notify.notify_one();
+    };
+    let server = axum::serve(listener, router)
+        .with_graceful_shutdown(graceful)
         .into_future();
     tokio::pin!(server);
     tokio::select! {
-        result = &mut server => result?,
+        result = &mut server => {
+            result?;
+            Ok(ShutdownOutcome::Drained)
+        }
         () = draining.notified() => {
-            match tokio::time::timeout(SHUTDOWN_GRACE, &mut server).await {
-                Ok(result) => result?,
-                Err(_) => tracing::warn!(
-                    grace_seconds = SHUTDOWN_GRACE.as_secs(),
-                    "shutdown grace expired; terminating remaining in-flight requests"
-                ),
+            match tokio::time::timeout(grace, &mut server).await {
+                Ok(result) => {
+                    result?;
+                    Ok(ShutdownOutcome::Drained)
+                }
+                Err(_) => {
+                    tracing::warn!(
+                        grace_seconds = grace.as_secs(),
+                        "shutdown grace expired; abandoning remaining in-flight requests"
+                    );
+                    Ok(ShutdownOutcome::GraceExpired)
+                }
             }
         }
     }
-    Ok(())
 }
 
-async fn shutdown_signal(draining: Arc<tokio::sync::Notify>) {
+async fn shutdown_signal() {
     let ctrl_c = async {
         if let Err(error) = tokio::signal::ctrl_c().await {
             tracing::error!(%error, "install Ctrl-C handler");
@@ -255,8 +318,6 @@ async fn shutdown_signal(draining: Arc<tokio::sync::Notify>) {
         () = ctrl_c => {},
         () = terminate => {},
     }
-    tracing::info!("shutdown requested; draining in-flight requests");
-    draining.notify_one();
 }
 
 async fn health() -> ApiResult<Value> {
@@ -670,7 +731,84 @@ mod tests {
     use axum::body::Body;
     use axum::http::Request;
     use http_body_util::BodyExt;
+    use tokio::io::AsyncWriteExt;
     use tower::ServiceExt;
+
+    async fn loopback_listener() -> (tokio::net::TcpListener, SocketAddr) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind loopback listener");
+        let address = listener.local_addr().expect("resolve listener address");
+        (listener, address)
+    }
+
+    #[tokio::test]
+    async fn a_completed_drain_reports_a_clean_shutdown() {
+        let (listener, _address) = loopback_listener().await;
+        let (trigger, shutdown) = tokio::sync::oneshot::channel::<()>();
+        let server = tokio::spawn(serve_with_shutdown(
+            listener,
+            Router::new().route("/quick", get(|| async { "ok" })),
+            SHUTDOWN_GRACE,
+            async move {
+                let _ = shutdown.await;
+            },
+        ));
+        trigger.send(()).expect("request shutdown");
+        let outcome = server
+            .await
+            .expect("server task")
+            .expect("server shutdown cleanly");
+        assert_eq!(outcome, ShutdownOutcome::Drained);
+        assert!(!outcome.grace_expired());
+    }
+
+    #[tokio::test]
+    async fn an_expired_grace_is_reported_instead_of_waiting_for_the_request() {
+        let (listener, address) = loopback_listener().await;
+        // The handler blocks far longer than the grace, so the drain cannot
+        // finish and the bound must be the thing that ends `serve`.
+        let started = Arc::new(tokio::sync::Notify::new());
+        let handler_started = started.clone();
+        let router = Router::new().route(
+            "/slow",
+            get(move || {
+                let started = handler_started.clone();
+                async move {
+                    started.notify_one();
+                    tokio::time::sleep(Duration::from_secs(3600)).await;
+                    "never"
+                }
+            }),
+        );
+        let (trigger, shutdown) = tokio::sync::oneshot::channel::<()>();
+        let server = tokio::spawn(serve_with_shutdown(
+            listener,
+            router,
+            Duration::from_millis(100),
+            async move {
+                let _ = shutdown.await;
+            },
+        ));
+        // Hold the connection open for the whole test: dropping it early would
+        // let the server finish the drain for the wrong reason.
+        let mut connection = tokio::net::TcpStream::connect(address)
+            .await
+            .expect("connect to the API");
+        connection
+            .write_all(b"GET /slow HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n")
+            .await
+            .expect("send a request that never completes");
+        started.notified().await;
+        trigger.send(()).expect("request shutdown");
+        let outcome = server
+            .await
+            .expect("server task")
+            .expect("server shutdown without a transport error");
+        assert_eq!(outcome, ShutdownOutcome::GraceExpired);
+        assert!(outcome.grace_expired());
+        drop(connection);
+    }
 
     #[tokio::test]
     async fn health_is_live_json_and_does_not_require_token() {

--- a/src/db.rs
+++ b/src/db.rs
@@ -323,6 +323,11 @@ impl Store {
             BEFORE DELETE ON validation_attempts
             BEGIN SELECT RAISE(ABORT, 'validation attempts are immutable'); END;
 
+            CREATE TRIGGER IF NOT EXISTS validation_attempts_no_replace
+            BEFORE INSERT ON validation_attempts
+            WHEN EXISTS(SELECT 1 FROM validation_attempts WHERE id = NEW.id)
+            BEGIN SELECT RAISE(ABORT, 'validation attempts are immutable'); END;
+
             CREATE TABLE IF NOT EXISTS decisions (
                 id TEXT PRIMARY KEY,
                 changeset_id TEXT REFERENCES changesets(id),
@@ -377,6 +382,16 @@ impl Store {
 
             CREATE TRIGGER IF NOT EXISTS conflict_detections_no_delete
             BEFORE DELETE ON conflict_detections
+            BEGIN SELECT RAISE(ABORT, 'conflict detections are immutable'); END;
+
+            -- INSERT OR REPLACE deletes the conflicting row first, and that
+            -- delete only fires the trigger above when recursive_triggers is
+            -- enabled, which is a per-connection setting an outside client does
+            -- not share. Rejecting an insert that reuses an existing id makes
+            -- the guarantee live in the schema instead.
+            CREATE TRIGGER IF NOT EXISTS conflict_detections_no_replace
+            BEFORE INSERT ON conflict_detections
+            WHEN EXISTS(SELECT 1 FROM conflict_detections WHERE id = NEW.id)
             BEGIN SELECT RAISE(ABORT, 'conflict detections are immutable'); END;
 
             CREATE TABLE IF NOT EXISTS coordination_messages (
@@ -443,14 +458,31 @@ impl Store {
         // are gated on this: re-running them on every open is what let a
         // duplicate legacy detection row be minted for conflicts that already
         // had a native one.
-        let stored_version: i64 = conn
+        let recorded_version: Option<String> = conn
             .query_row(
-                "SELECT CAST(value AS INTEGER) FROM meta WHERE key = 'schema_version'",
+                "SELECT value FROM meta WHERE key = 'schema_version'",
                 [],
                 |row| row.get(0),
             )
-            .optional()?
-            .unwrap_or(0);
+            .optional()?;
+        let stored_version: i64 = match recorded_version {
+            // Parsed strictly. A CAST would silently read a malformed value as
+            // zero, which would rerun every one-time backfill against a store
+            // that has already had them applied.
+            Some(value) => value.trim().parse::<i64>().map_err(|_| {
+                anyhow::anyhow!(
+                    "CORRUPT_STORE: schema_version is not an integer: {value:?}; this database was not written by Foremerge or is damaged"
+                )
+            })?,
+            None => 0,
+        };
+        if stored_version > DATABASE_SCHEMA_VERSION {
+            // Migrating downwards would rewrite the stamp and let this build
+            // write a store it does not understand.
+            bail!(
+                "UNSUPPORTED_SCHEMA: database schema {stored_version} is newer than this build supports ({DATABASE_SCHEMA_VERSION}); upgrade Foremerge to open it"
+            );
+        }
         let has_supersedes: bool = conn.query_row(
             "SELECT EXISTS(
                SELECT 1 FROM pragma_table_info('changesets') WHERE name = 'supersedes_changeset_id'
@@ -491,14 +523,20 @@ impl Store {
         )?;
         if stored_version < 2 {
             conn.execute(
-                "INSERT OR IGNORE INTO validation_attempts(
+                // Explicit NOT EXISTS rather than OR IGNORE: the append-only
+                // insert guard raises, and a raise is not a constraint
+                // violation that OR IGNORE would swallow.
+                "INSERT INTO validation_attempts(
                    id, changeset_id, command_json, passed, exit_code, stdout, stderr, duration_ms,
                    expected_fingerprint, observed_fingerprint, authoritative, stale_reason,
                    changed_files_json, excluded_paths_json, exclusion_ruleset_digest, run_at
                  )
                  SELECT id, changeset_id, command_json, passed, exit_code, stdout, stderr,
                         duration_ms, fingerprint, fingerprint, 1, NULL, '[]', '[]', 'legacy', run_at
-                 FROM validations",
+                 FROM validations
+                 WHERE NOT EXISTS(
+                     SELECT 1 FROM validation_attempts a WHERE a.id = validations.id
+                 )",
                 [],
             )?;
         }
@@ -578,7 +616,7 @@ impl Store {
             // duplicate for every conflict that already recorded a native
             // detection.
             conn.execute(
-                "INSERT OR IGNORE INTO conflict_detections(
+                "INSERT INTO conflict_detections(
                    id, conflict_id, severity, score, scope_json, explanation, suggestion,
                    evidence_json, previously_settled, detected_at
                  )
@@ -601,6 +639,10 @@ impl Store {
             // append-only trigger is dropped for the length of this repair and
             // restored inside the same transaction.
             conn.execute_batch("DROP TRIGGER IF EXISTS conflict_detections_no_delete;")?;
+            // Only a byte-identical twin is a phantom. A legacy row that
+            // differs from every native row is a genuine earlier observation,
+            // typically the sole record of a detection that predates schema 2,
+            // and deleting it would destroy real history.
             let repaired = conn.execute(
                 "DELETE FROM conflict_detections
                  WHERE id LIKE 'dtn\\_legacy\\_%' ESCAPE '\\'
@@ -608,6 +650,15 @@ impl Store {
                        SELECT 1 FROM conflict_detections other
                        WHERE other.conflict_id = conflict_detections.conflict_id
                          AND other.id NOT LIKE 'dtn\\_legacy\\_%' ESCAPE '\\'
+                         AND other.detected_at = conflict_detections.detected_at
+                         AND other.severity = conflict_detections.severity
+                         AND other.score = conflict_detections.score
+                         AND other.explanation = conflict_detections.explanation
+                         AND other.suggestion = conflict_detections.suggestion
+                         AND other.evidence_json = conflict_detections.evidence_json
+                         AND other.previously_settled = conflict_detections.previously_settled
+                         AND IFNULL(other.scope_json, '')
+                             = IFNULL(conflict_detections.scope_json, '')
                    )",
                 [],
             )?;
@@ -1260,5 +1311,215 @@ mod tests {
         symlink(&target, &link).unwrap();
         let error = Store::open(&link).err().expect("symlink must be rejected");
         assert!(format!("{error:#}").starts_with("INVALID_INPUT:"));
+    }
+}
+
+#[cfg(test)]
+mod schema_repair_tests {
+    use super::*;
+
+    /// Conflicts reference intents, which reference a task and an agent, so a
+    /// fixture needs the whole chain before it can seed a detection.
+    fn seed_intents(conn: &Connection) {
+        conn.execute(
+            "INSERT INTO agents(id, name, model, capabilities_json, worktree, git_branch,
+             git_head, status, registered_at, last_seen_at)
+             VALUES('agt_x', 'fixture', 'test', '[]', NULL, NULL, NULL, 'ACTIVE',
+                    '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')",
+            [],
+        )
+        .expect("seed agent");
+        conn.execute(
+            "INSERT INTO tasks(id, task_key, title, created_by_agent_id, created_at)
+             VALUES('tsk_x', 'fixture', 'fixture', 'agt_x', '2026-01-01T00:00:00Z')",
+            [],
+        )
+        .expect("seed task");
+        for intent in ["int_a", "int_b"] {
+            conn.execute(
+                "INSERT INTO intents(id, agent_id, task_id, summary, rationale, scopes_json,
+                 depends_on_json, metadata_json, status, created_at, updated_at)
+                 VALUES(?1, 'agt_x', 'tsk_x', 'fixture intent', NULL, '[]', '[]', '{}', 'INTENT',
+                        '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')",
+                params![intent],
+            )
+            .expect("seed intent");
+        }
+    }
+
+    fn seed_conflict(conn: &Connection, id: &str, detected_at: &str) {
+        conn.execute(
+            "INSERT INTO conflicts(id, kind, severity, score, source_intent_id, target_intent_id,
+             scope_json, scope_identity, explanation, suggestion, evidence_json, status, detected_at)
+             VALUES(?1, 'replace_vs_extend', 'HIGH', 0.9, 'int_a', 'int_b', NULL, ?1,
+                    'shared scope', 'coordinate', '{}', 'OPEN', ?2)",
+            params![id, detected_at],
+        )
+        .expect("seed conflict");
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn seed_detection(conn: &Connection, id: &str, conflict: &str, explanation: &str, at: &str) {
+        conn.execute(
+            "INSERT INTO conflict_detections(id, conflict_id, severity, score, scope_json,
+             explanation, suggestion, evidence_json, previously_settled, detected_at)
+             VALUES(?1, ?2, 'HIGH', 0.9, NULL, ?3, 'coordinate', '{}', 0, ?4)",
+            params![id, conflict, explanation, at],
+        )
+        .expect("seed detection");
+    }
+
+    fn detection_ids(conn: &Connection, conflict: &str) -> Vec<String> {
+        let mut statement = conn
+            .prepare("SELECT id FROM conflict_detections WHERE conflict_id = ?1 ORDER BY id")
+            .expect("prepare");
+        statement
+            .query_map([conflict], |row| row.get::<_, String>(0))
+            .expect("query")
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .expect("collect")
+    }
+
+    /// Schema 2 minted a byte-identical twin for a conflict that already had a
+    /// native observation. Only that twin may be removed.
+    #[test]
+    fn repair_removes_only_byte_identical_phantoms() {
+        let store = Store::in_memory().expect("open store");
+        let conn = store.lock().expect("lock");
+        seed_intents(&conn);
+        seed_conflict(&conn, "cfl_phantom", "2026-03-01T00:00:00Z");
+        seed_detection(
+            &conn,
+            "dtn_native_p",
+            "cfl_phantom",
+            "same",
+            "2026-03-01T00:00:00Z",
+        );
+        seed_detection(
+            &conn,
+            "dtn_legacy_cfl_phantom",
+            "cfl_phantom",
+            "same",
+            "2026-03-01T00:00:00Z",
+        );
+
+        seed_conflict(&conn, "cfl_genuine", "2026-01-01T00:00:00Z");
+        seed_detection(
+            &conn,
+            "dtn_legacy_cfl_genuine",
+            "cfl_genuine",
+            "early observation",
+            "2026-01-01T00:00:00Z",
+        );
+        seed_detection(
+            &conn,
+            "dtn_native_later",
+            "cfl_genuine",
+            "later observation",
+            "2026-02-01T00:00:00Z",
+        );
+
+        conn.execute(
+            "UPDATE meta SET value = '2' WHERE key = 'schema_version'",
+            [],
+        )
+        .expect("pretend the store was written by schema 2");
+        Store::migrate(&conn).expect("repair migration");
+
+        assert_eq!(
+            detection_ids(&conn, "cfl_phantom"),
+            vec!["dtn_native_p".to_string()],
+            "the identical twin must be removed"
+        );
+        assert_eq!(
+            detection_ids(&conn, "cfl_genuine"),
+            vec![
+                "dtn_legacy_cfl_genuine".to_string(),
+                "dtn_native_later".to_string()
+            ],
+            "a genuine earlier observation must survive a later redetection"
+        );
+
+        // Repeat opens must not remove anything else or reintroduce a twin.
+        Store::migrate(&conn).expect("second open");
+        Store::migrate(&conn).expect("third open");
+        assert_eq!(detection_ids(&conn, "cfl_phantom").len(), 1);
+        assert_eq!(detection_ids(&conn, "cfl_genuine").len(), 2);
+    }
+
+    /// An insert reusing an existing id is how INSERT OR REPLACE overwrites an
+    /// append-only row. The guard must live in the schema, not in a
+    /// per-connection pragma.
+    #[test]
+    fn reusing_an_immutable_id_is_rejected() {
+        let store = Store::in_memory().expect("open store");
+        let conn = store.lock().expect("lock");
+        seed_intents(&conn);
+        seed_conflict(&conn, "cfl_a", "2026-01-01T00:00:00Z");
+        seed_detection(&conn, "dtn_a", "cfl_a", "original", "2026-01-01T00:00:00Z");
+        let replaced = conn.execute(
+            "INSERT OR REPLACE INTO conflict_detections(id, conflict_id, severity, score,
+             scope_json, explanation, suggestion, evidence_json, previously_settled, detected_at)
+             VALUES('dtn_a', 'cfl_a', 'HIGH', 0.9, NULL, 'tampered', 'coordinate', '{}', 0,
+                    '2026-01-01T00:00:00Z')",
+            [],
+        );
+        assert!(
+            replaced.is_err(),
+            "REPLACE must not overwrite an observation"
+        );
+        let explanation: String = conn
+            .query_row(
+                "SELECT explanation FROM conflict_detections WHERE id = 'dtn_a'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("read back");
+        assert_eq!(explanation, "original");
+    }
+
+    #[test]
+    fn a_newer_schema_is_refused_and_left_untouched() {
+        let store = Store::in_memory().expect("open store");
+        let conn = store.lock().expect("lock");
+        let future = DATABASE_SCHEMA_VERSION + 1;
+        conn.execute(
+            "UPDATE meta SET value = ?1 WHERE key = 'schema_version'",
+            [future.to_string()],
+        )
+        .expect("stamp a future version");
+        let error = Store::migrate(&conn).expect_err("a newer store must be refused");
+        assert!(
+            format!("{error:#}").contains("UNSUPPORTED_SCHEMA"),
+            "unexpected error: {error:#}"
+        );
+        let recorded: String = conn
+            .query_row(
+                "SELECT value FROM meta WHERE key = 'schema_version'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("read version");
+        assert_eq!(
+            recorded,
+            future.to_string(),
+            "refusing must not rewrite the stamp"
+        );
+    }
+
+    #[test]
+    fn a_malformed_schema_version_is_corrupt_not_zero() {
+        let store = Store::in_memory().expect("open store");
+        let conn = store.lock().expect("lock");
+        conn.execute(
+            "UPDATE meta SET value = 'banana' WHERE key = 'schema_version'",
+            [],
+        )
+        .expect("stamp a malformed version");
+        let error = Store::migrate(&conn).expect_err("a malformed version must be refused");
+        assert!(
+            format!("{error:#}").contains("CORRUPT_STORE"),
+            "unexpected error: {error:#}"
+        );
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -11,7 +11,7 @@ use std::sync::{Arc, Mutex, MutexGuard, TryLockError};
 use std::time::Duration;
 use uuid::Uuid;
 
-const DATABASE_SCHEMA_VERSION: i64 = 2;
+const DATABASE_SCHEMA_VERSION: i64 = 3;
 // Event hashing is versioned independently from the mutable SQLite projection
 // schema. A database migration must not silently change the hash material for
 // otherwise identical events.
@@ -123,7 +123,12 @@ impl Store {
     fn configure(conn: &Connection) -> Result<()> {
         conn.busy_timeout(Duration::from_secs(10))?;
         conn.execute_batch(
+            // Recursive triggers make the append-only triggers fire for the
+            // implicit delete inside an INSERT OR REPLACE. Without it, REPLACE
+            // silently bypasses the immutability guards on validation_attempts,
+            // conflict_detections, and events.
             "PRAGMA foreign_keys = ON;
+             PRAGMA recursive_triggers = ON;
              PRAGMA journal_mode = WAL;
              PRAGMA synchronous = NORMAL;",
         )?;
@@ -156,6 +161,21 @@ impl Store {
     }
 
     fn migrate(conn: &Connection) -> Result<()> {
+        // One transaction for the whole migration. A partially applied
+        // migration would otherwise leave derived projections incomplete, and
+        // an incomplete intent_scopes projection silently omits intents from
+        // scope queries, which is worse than failing to open.
+        // IMMEDIATE, not the default DEFERRED: migration always writes, and a
+        // deferred transaction would take a read lock first and then deadlock
+        // on the upgrade when two processes open the same store at once,
+        // failing instantly instead of waiting out the busy timeout.
+        let tx = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+        Self::migrate_in(&tx)?;
+        tx.commit()?;
+        Ok(())
+    }
+
+    fn migrate_in(conn: &Connection) -> Result<()> {
         conn.execute_batch(
             r#"
             CREATE TABLE IF NOT EXISTS meta (
@@ -418,6 +438,19 @@ impl Store {
             BEGIN SELECT RAISE(ABORT, 'event log is append-only'); END;
             "#,
         )?;
+        // The schema version the store was last written with. Absent means a
+        // brand new database, or one predating the stamp. One-time backfills
+        // are gated on this: re-running them on every open is what let a
+        // duplicate legacy detection row be minted for conflicts that already
+        // had a native one.
+        let stored_version: i64 = conn
+            .query_row(
+                "SELECT CAST(value AS INTEGER) FROM meta WHERE key = 'schema_version'",
+                [],
+                |row| row.get(0),
+            )
+            .optional()?
+            .unwrap_or(0);
         let has_supersedes: bool = conn.query_row(
             "SELECT EXISTS(
                SELECT 1 FROM pragma_table_info('changesets') WHERE name = 'supersedes_changeset_id'
@@ -456,21 +489,31 @@ impl Store {
              WHERE integration_commit IS NULL AND status = 'COMMITTED'",
             [],
         )?;
-        conn.execute(
-            "INSERT OR IGNORE INTO validation_attempts(
-               id, changeset_id, command_json, passed, exit_code, stdout, stderr, duration_ms,
-               expected_fingerprint, observed_fingerprint, authoritative, stale_reason,
-               changed_files_json, excluded_paths_json, exclusion_ruleset_digest, run_at
-             )
-             SELECT id, changeset_id, command_json, passed, exit_code, stdout, stderr, duration_ms,
-                    fingerprint, fingerprint, 1, NULL, '[]', '[]', 'legacy', run_at
-             FROM validations",
-            [],
-        )?;
-        let mut statement = conn.prepare(
-            "SELECT id, scopes_json FROM intents
-             WHERE NOT EXISTS(SELECT 1 FROM intent_scopes s WHERE s.intent_id = intents.id)",
-        )?;
+        if stored_version < 2 {
+            conn.execute(
+                "INSERT OR IGNORE INTO validation_attempts(
+                   id, changeset_id, command_json, passed, exit_code, stdout, stderr, duration_ms,
+                   expected_fingerprint, observed_fingerprint, authoritative, stale_reason,
+                   changed_files_json, excluded_paths_json, exclusion_ruleset_digest, run_at
+                 )
+                 SELECT id, changeset_id, command_json, passed, exit_code, stdout, stderr,
+                        duration_ms, fingerprint, fingerprint, 1, NULL, '[]', '[]', 'legacy', run_at
+                 FROM validations",
+                [],
+            )?;
+        }
+        // Below schema 3 a projection could have been left partially written by
+        // an interrupted migration, so every intent is reprojected once.
+        // Afterwards only intents with no projection at all need work, which is
+        // the ordinary case of a store written by an older binary.
+        let mut statement = if stored_version < 3 {
+            conn.prepare("SELECT id, scopes_json FROM intents")?
+        } else {
+            conn.prepare(
+                "SELECT id, scopes_json FROM intents
+                 WHERE NOT EXISTS(SELECT 1 FROM intent_scopes s WHERE s.intent_id = intents.id)",
+            )?
+        };
         let intent_scopes = statement
             .query_map([], |row| {
                 Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
@@ -529,18 +572,57 @@ impl Store {
             [],
         )
         .context("create canonical conflict identity index")?;
-        conn.execute(
-            "INSERT OR IGNORE INTO conflict_detections(
-               id, conflict_id, severity, score, scope_json, explanation, suggestion,
-               evidence_json, previously_settled, detected_at
-             )
-             SELECT 'dtn_legacy_' || id, id, severity, score, scope_json, explanation,
-                    suggestion, evidence_json,
-                    CASE WHEN status IN ('OPEN', 'COORDINATING') THEN 0 ELSE 1 END,
-                    detected_at
-             FROM conflicts",
-            [],
-        )?;
+        if stored_version < 2 {
+            // Only conflicts carrying no observation of their own need a
+            // synthesized one. Without the NOT EXISTS guard this mints a
+            // duplicate for every conflict that already recorded a native
+            // detection.
+            conn.execute(
+                "INSERT OR IGNORE INTO conflict_detections(
+                   id, conflict_id, severity, score, scope_json, explanation, suggestion,
+                   evidence_json, previously_settled, detected_at
+                 )
+                 SELECT 'dtn_legacy_' || id, id, severity, score, scope_json, explanation,
+                        suggestion, evidence_json,
+                        CASE WHEN status IN ('OPEN', 'COORDINATING') THEN 0 ELSE 1 END,
+                        detected_at
+                 FROM conflicts
+                 WHERE NOT EXISTS(
+                     SELECT 1 FROM conflict_detections d WHERE d.conflict_id = conflicts.id
+                 )",
+                [],
+            )?;
+        }
+        if stored_version == 2 {
+            // Schema 2 minted a synthesized detection for every conflict on
+            // every open, so conflicts that already had a native observation
+            // carry a duplicate. Remove only those duplicates: a legacy row is
+            // genuine when it is the conflict's sole observation. The
+            // append-only trigger is dropped for the length of this repair and
+            // restored inside the same transaction.
+            conn.execute_batch("DROP TRIGGER IF EXISTS conflict_detections_no_delete;")?;
+            let repaired = conn.execute(
+                "DELETE FROM conflict_detections
+                 WHERE id LIKE 'dtn\\_legacy\\_%' ESCAPE '\\'
+                   AND EXISTS(
+                       SELECT 1 FROM conflict_detections other
+                       WHERE other.conflict_id = conflict_detections.conflict_id
+                         AND other.id NOT LIKE 'dtn\\_legacy\\_%' ESCAPE '\\'
+                   )",
+                [],
+            )?;
+            conn.execute_batch(
+                "CREATE TRIGGER IF NOT EXISTS conflict_detections_no_delete
+                 BEFORE DELETE ON conflict_detections
+                 BEGIN SELECT RAISE(ABORT, 'conflict detections are immutable'); END;",
+            )?;
+            if repaired > 0 {
+                tracing::info!(
+                    removed = repaired,
+                    "removed duplicate conflict detections written by schema 2"
+                );
+            }
+        }
         conn.execute(
             "INSERT INTO meta(key, value) VALUES('schema_version', ?1)
              ON CONFLICT(key) DO UPDATE SET value = excluded.value",

--- a/src/git.rs
+++ b/src/git.rs
@@ -384,6 +384,20 @@ pub fn ensure_clean(worktree: impl AsRef<Path>) -> Result<()> {
             snapshot.changed_files.join(", ")
         );
     }
+    // Excluded generated files are deliberately kept out of the fingerprint, so
+    // they do not make the worktree dirty. They must still be gone before
+    // acceptance: the validated tree contained them and the accepted commit
+    // does not, so leaving them lets a candidate be accepted whose validation
+    // depended on content that is not in the commit. Deleting them cannot
+    // invalidate the ChangeSet, because their presence and content were
+    // excluded from the fingerprint in the first place.
+    if !snapshot.excluded_paths.is_empty() {
+        bail!(
+            "CHECK_FAILED: worktree {} still holds excluded generated files; remove them before acceptance (this does not change the fingerprint): {}",
+            snapshot.root.display(),
+            snapshot.excluded_paths.join(", ")
+        );
+    }
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -451,8 +451,25 @@ struct RequestArgs {
     url: String,
 }
 
-#[tokio::main]
-async fn main() {
+/// How the requested command finished, so `main` can pick an exit code without
+/// inspecting command state again.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Completion {
+    /// The command finished normally.
+    Normal,
+    /// The daemon's shutdown grace expired with HTTP work still in flight, so
+    /// the process is exiting on the bound rather than on a completed drain.
+    ForcedShutdown,
+}
+
+fn exit_code(completion: Completion) -> i32 {
+    match completion {
+        Completion::Normal => 0,
+        Completion::ForcedShutdown => 1,
+    }
+}
+
+fn main() {
     let cli = Cli::parse();
     let mcp_mode = matches!(&cli.command, Commands::Mcp);
     tracing_subscriber::fmt()
@@ -462,37 +479,68 @@ async fn main() {
         .with_writer(std::io::stderr)
         .init();
     let json_mode = cli.json;
-    if let Err(error) = execute(cli).await {
-        if error
-            .downcast_ref::<io::Error>()
-            .is_some_and(|value| value.kind() == io::ErrorKind::BrokenPipe)
-        {
-            return;
+    // The runtime is built by hand rather than through `#[tokio::main]` so the
+    // process can bound its own teardown: `shutdown_timeout` drops pending
+    // tasks (running validation cancellation guards) and then stops waiting on
+    // blocking work that cannot be cancelled, such as a wedged child process.
+    let runtime = match tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(runtime) => runtime,
+        Err(error) => {
+            eprintln!("error: build Tokio runtime: {error}");
+            std::process::exit(1);
         }
-        if json_mode && !mcp_mode {
-            let line = serde_json::to_string(&json!({
-                "ok": false,
-                "error": { "code": error_code(&error), "message": format!("{error:#}") }
-            }))
-            .expect("serialize error");
-            if let Err(write_error) = write_stdout_line(&line) {
-                if write_error
-                    .downcast_ref::<io::Error>()
-                    .is_none_or(|value| value.kind() != io::ErrorKind::BrokenPipe)
-                {
-                    eprintln!("error: {write_error:#}");
-                }
+    };
+    let code = match runtime.block_on(execute(cli)) {
+        Ok(completion) => {
+            if completion == Completion::ForcedShutdown {
+                eprintln!(
+                    "error: shutdown grace of {} seconds expired with requests still in flight; exiting without waiting for them",
+                    api::shutdown_grace().as_secs()
+                );
             }
-        } else {
-            eprintln!("error: {error:#}");
+            exit_code(completion)
         }
-        std::process::exit(1);
-    }
+        Err(error) => {
+            if error
+                .downcast_ref::<io::Error>()
+                .is_some_and(|value| value.kind() == io::ErrorKind::BrokenPipe)
+            {
+                0
+            } else {
+                if json_mode && !mcp_mode {
+                    let line = serde_json::to_string(&json!({
+                        "ok": false,
+                        "error": { "code": error_code(&error), "message": format!("{error:#}") }
+                    }))
+                    .expect("serialize error");
+                    if let Err(write_error) = write_stdout_line(&line) {
+                        if write_error
+                            .downcast_ref::<io::Error>()
+                            .is_none_or(|value| value.kind() != io::ErrorKind::BrokenPipe)
+                        {
+                            eprintln!("error: {write_error:#}");
+                        }
+                    }
+                } else {
+                    eprintln!("error: {error:#}");
+                }
+                1
+            }
+        }
+    };
+    // Bounded teardown, then a deliberate exit: without both, dropping the
+    // runtime would block indefinitely on an uncancellable blocking task.
+    runtime.shutdown_timeout(api::RUNTIME_SHUTDOWN_GRACE);
+    std::process::exit(code);
 }
 
-async fn execute(cli: Cli) -> Result<()> {
+async fn execute(cli: Cli) -> Result<Completion> {
     let cwd = cli.cwd.canonicalize().unwrap_or(cli.cwd.clone());
     let database = git::resolve_database_path(&cwd, cli.database.as_deref());
+    let mut completion = Completion::Normal;
     match cli.command {
         Commands::Init => {
             let service = open_service(&database, &cwd)?;
@@ -643,7 +691,10 @@ async fn execute(cli: Cli) -> Result<()> {
             if !cli.json {
                 eprintln!("Foremerge API listening on http://{bind}");
             }
-            api::serve(ApiState { service, token }, bind).await?;
+            let outcome = api::serve(ApiState { service, token }, bind).await?;
+            if outcome.grace_expired() {
+                completion = Completion::ForcedShutdown;
+            }
         }
         Commands::Mcp => {
             let service = open_service(&database, &cwd)?;
@@ -722,7 +773,7 @@ async fn execute(cli: Cli) -> Result<()> {
             execute_service(command, service, &cwd, cli.json).await?;
         }
     }
-    Ok(())
+    Ok(completion)
 }
 
 fn open_service(database: &Path, cwd: &Path) -> Result<Foremerge> {
@@ -1285,4 +1336,23 @@ fn error_code_from_message(message: &str) -> String {
         })
         .unwrap_or("ERROR")
         .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_forced_shutdown_is_reported_through_a_nonzero_exit_code() {
+        assert_eq!(exit_code(Completion::Normal), 0);
+        assert_eq!(exit_code(Completion::ForcedShutdown), 1);
+    }
+
+    #[test]
+    fn the_runtime_teardown_bound_is_finite_and_shorter_than_the_http_grace() {
+        // The documented worst case is the HTTP grace plus this bound, so a
+        // teardown bound at or above the grace would silently double it.
+        assert!(api::RUNTIME_SHUTDOWN_GRACE > Duration::ZERO);
+        assert!(api::RUNTIME_SHUTDOWN_GRACE < api::shutdown_grace());
+    }
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -1042,6 +1042,18 @@ impl Foremerge {
                 fingerprint_diagnostic(&changeset, &current)
             );
         }
+        // Exclusions exist so a check may CREATE generated files without
+        // invalidating its own fingerprint. A file already present when the
+        // command starts is different: the command may consume it, so a pass
+        // could depend on content that is not in the candidate commit and is
+        // not covered by the fingerprint. Requiring a clean start means every
+        // excluded path observed afterwards was produced by this run.
+        if !current.excluded_paths.is_empty() {
+            bail!(
+                "CHECK_FAILED: excluded generated files are already present, so validation could consume content that is not in the candidate commit; remove them and validate again (this does not change the fingerprint): {}",
+                current.excluded_paths.join(", ")
+            );
+        }
 
         let started = Instant::now();
         let mut command = Command::new(&request.command[0]);

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -837,6 +837,20 @@ fn stale_validation_attempt_is_retained_and_exclusion_rules_enable_a_safe_revisi
             .is_some_and(|digest| digest.starts_with("sha256:"))
     );
 
+    // The excluded artifact is deliberately outside the fingerprint, so it does
+    // not make the worktree dirty. Acceptance must still refuse while it is
+    // present: the validated tree contained it and the accepted commit does
+    // not, so accepting here would bless a candidate whose validation may have
+    // depended on content missing from the commit.
+    let blocked = cli_failure(&repo.root, None, ["changeset", "accept", &second_changeset]);
+    assert_eq!(blocked["error"]["code"], "CHECK_FAILED");
+    assert!(
+        blocked["error"]["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("coverage.log")),
+        "acceptance must name the excluded artifact: {blocked}"
+    );
+
     fs::remove_file(repo.root.join("coverage.log")).expect("remove generated artifact");
     let accepted = cli_success(&repo.root, None, ["changeset", "accept", &second_changeset]);
     assert_eq!(accepted["data"]["status"], "ACCEPTED");
@@ -4947,5 +4961,101 @@ fn real_mcp_stdio_drives_the_lifecycle_through_named_verification_and_acceptance
             .expect("open lifecycle database")
             .verify_event_chain()
             .unwrap()
+    );
+}
+
+/// Every CLI invocation reopens the store and therefore reruns migration. A
+/// one-time backfill that is not gated on the stored schema version mints a
+/// duplicate row on the second open, which is how schema 2 fabricated a second
+/// "immutable" detection for conflicts that already had a native one. The
+/// in-process tests could not see this because they never reopen.
+#[test]
+fn reopening_the_store_does_not_fabricate_extra_conflict_detections() {
+    let repo = create_repo();
+    cli_success(&repo.root, None, ["init"]);
+    let first = cli_success(
+        &repo.root,
+        None,
+        ["agent", "register", "--name", "stripe", "--no-worktree"],
+    )["data"]["id"]
+        .as_str()
+        .expect("agent id")
+        .to_string();
+    let second = cli_success(
+        &repo.root,
+        None,
+        ["agent", "register", "--name", "paypal", "--no-worktree"],
+    )["data"]["id"]
+        .as_str()
+        .expect("agent id")
+        .to_string();
+    cli_success(
+        &repo.root,
+        None,
+        [
+            "intent",
+            "publish",
+            "--agent",
+            &first,
+            "--task",
+            "modernize",
+            "--summary",
+            "Replace PaymentService with StripePaymentService",
+            "--scope",
+            "symbol:PaymentService",
+        ],
+    );
+    cli_success(
+        &repo.root,
+        None,
+        [
+            "intent",
+            "publish",
+            "--agent",
+            &second,
+            "--task",
+            "paypal",
+            "--summary",
+            "Add PayPal support to PaymentService",
+            "--scope",
+            "symbol:PaymentService",
+        ],
+    );
+    let conflicts = cli_success(&repo.root, None, ["conflicts", "list"]);
+    let conflict_id = conflicts["data"][0]["id"]
+        .as_str()
+        .expect("a conflict was detected")
+        .to_string();
+
+    // Each of these is a separate process, so each reopens and remigrates.
+    for _ in 0..3 {
+        cli_success(&repo.root, None, ["status"]);
+    }
+
+    let detections = cli_success(&repo.root, None, ["conflicts", "detections", &conflict_id]);
+    let observations = detections["data"].as_array().expect("detections array");
+    assert_eq!(
+        observations.len(),
+        1,
+        "one detection must record exactly one observation across reopens: {detections}"
+    );
+    assert!(
+        !observations[0]["id"]
+            .as_str()
+            .expect("detection id")
+            .starts_with("dtn_legacy_"),
+        "a natively detected conflict must not be backfilled as legacy: {detections}"
+    );
+
+    let events = cli_success(&repo.root, None, ["events", "list", "--after-seq", "0"]);
+    let detected = events["data"]
+        .as_array()
+        .expect("events array")
+        .iter()
+        .filter(|event| event["event_type"] == "conflict.detected")
+        .count();
+    assert_eq!(
+        detected, 1,
+        "the event log and the occurrence table must agree: {events}"
     );
 }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -805,6 +805,30 @@ fn stale_validation_attempt_is_retained_and_exclusion_rules_enable_a_safe_revisi
         &intent_id,
         "Candidate with digest-bound artifact policy",
     );
+    // A validation must begin with no excluded artifacts present, so the
+    // leftover from the previous run has to go first. Otherwise this run could
+    // consume content that is not in the candidate commit, and Foremerge cannot
+    // tell consumption from overwriting.
+    let stale_artifact = cli_failure(
+        &repo.root,
+        None,
+        vec![
+            "changeset".to_string(),
+            "validate".to_string(),
+            second_changeset.clone(),
+            "--".to_string(),
+            "true".to_string(),
+        ],
+    );
+    assert_eq!(stale_artifact["error"]["code"], "CHECK_FAILED");
+    assert!(
+        stale_artifact["error"]["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("coverage.log")),
+        "the refusal must name the artifact: {stale_artifact}"
+    );
+    fs::remove_file(repo.root.join("coverage.log")).expect("clear the previous artifact");
+
     let validation = cli_success(
         &repo.root,
         None,


### PR DESCRIPTION
Fixes the four HIGH defects found reviewing v0.3.0, plus the systemic cause behind two of them. Full review with evidence: `foremerge-ops/reviews/2026-08-23-v0.3.0-review.md`.

## What was wrong

**Excluded files survived into acceptance.** `README.md`, `docs/limitations.md`, and ADR 0001 all state generated files must be removed before acceptance. Nothing enforced it. Excluded paths are kept out of `changed_files`, so `dirty` was false and `ensure_clean` passed with the file present. With a plausible rule like `node_modules/`, a ChangeSet could be accepted whose validation passed *because of* a file absent from the accepted commit, and checking out that commit fails the same check. This is the claim the product rests on.

**An interrupted migration silently lost intent scopes.** `migrate` had no transaction, and the skip guard was per-intent rather than per-scope, so an intent left holding some of its rows was skipped forever. Reproduced with `kill -9` two of three times. The result was a scope query returning fewer intents, exit code zero, no warning: the coordinator reporting nobody is touching a scope when somebody is.

**A phantom detection was minted on every store.** The backfill ran on every `Store::open` with no guard, so any conflict with a native occurrence got a duplicate `dtn_legacy_*` row on the next process start. Reproduced on a brand new database: one detection, two "immutable" observations, one event. The immutability trigger made it unremovable.

**Shutdown was not a process-exit bound.** The 30 second grace applied only to the HTTP future; dropping the runtime then blocked on uncancellable blocking work, leaving the daemon alive past 76 seconds with signals swallowed.

## Systemic cause

`DATABASE_SCHEMA_VERSION` was written but never read, so every backfill reran on every open. Reading it and gating on it fixes two of the four and removes a full rescan of `intents`, `conflicts`, and `validations` from every CLI invocation.

## Verification

- Fresh store: one detection, one occurrence, one event (was two occurrences).
- Store damaged by the shipped v0.3.0: repaired to one occurrence on first open, idempotent across reopens.
- Genuine 0.2.0 upgrade: legacy occurrence still synthesized where it is the only one, scope projection complete, event chain still verifies.
- `kill -9` mid-migration three times on a 20,001 intent store: complete projection or full rollback, never partial, and every reopen heals to 80,004 rows.
- Documented exclusion workflow end to end: validation writes the excluded file and passes, acceptance refuses and names it, removal lets acceptance succeed.
- `make verify`, `make msrv` on pinned 1.85, `make benchmarks` all green. 60 unit, 50 e2e.
- External dogfood harness 8/8 against a GPTree sandbox clone.
- Daemon SIGTERM exits cleanly in under a second.

## Migration note

Schema 3. Stores written by v0.3.0 are repaired on first open. No user action needed.

## Not included

The MEDIUM findings, notably that acceptance reads `validations` (the one table without append-only triggers) and that `authoritative` means the fingerprint matched at both ends rather than that the command observed the fingerprinted tree. Those are tracked in the review document.