### PR TITLE
Protect the acceptance gate table and define what authoritative asserts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ changes when they are called out here with a migration note.
   duplicates on first open, keeping genuine legacy rows where they are a
   conflict's only observation. Gating also removes a full rescan of `intents`,
   `conflicts`, and `validations` from every CLI invocation.
+- The `validations` projection is append-only. It is the table acceptance
+  actually reads, and it was the only one of the four record tables with no
+  guard, so a rewritten or replaced row could turn a failing gate into a passing
+  one while the audit tables looked untouched.
 - Reusing the id of an existing `validation_attempts` or `conflict_detections`
   row is rejected by the schema itself. `INSERT OR REPLACE` deletes the
   conflicting row first, and that delete only fires the append-only trigger when

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -72,6 +72,17 @@ Passing Foremerge-executed validation is a gate; agent-reported tests are
 provenance only. A passing command is not proof that the chosen validation was
 complete or that the software has no defects.
 
+`authoritative` has a precise and limited meaning: the worktree fingerprint was
+identical immediately before and immediately after the command, and the
+ChangeSet revision and lifecycle state did not change while it ran. It does not
+assert that the command observed the fingerprinted tree. A command that mutates
+tracked files, tests the mutated tree, and restores it before exiting leaves the
+fingerprint unchanged and is recorded as authoritative. Foremerge samples the
+endpoints; it does not watch the tree during the run, and it does not sandbox
+the command. Named checks over MCP narrow this because an agent chooses only
+which registered check runs, never its argument vector; a caller using the CLI
+or the HTTP API supplies the command directly and is trusted accordingly.
+
 Every completed command is retained as local audit data even when its result is
 stale and non-authoritative. Validation stdout/stderr can contain secrets.
 Digest-bound exclusions can hide only explicitly listed untracked generated

--- a/docs/state-model.md
+++ b/docs/state-model.md
@@ -161,6 +161,13 @@ short final transaction then reloads the ChangeSet and intent, verifies the
 current revision/state, compares the captured fingerprint, appends the attempt,
 and applies lifecycle state only when the result remains authoritative.
 
+`authoritative` therefore means the endpoints agreed: the fingerprint was
+identical before and after the run, and the revision and lifecycle state held.
+It is not a claim that the command read the fingerprinted tree, because
+Foremerge samples the worktree around the command rather than watching it during
+execution. See [limitations](limitations.md) for what that does and does not
+rule out.
+
 Every completed command is retained in immutable `validation_attempts`, even if
 a concurrent revision, acceptance, or worktree mutation makes it stale. Such an
 attempt records `authoritative: false`, a reason, expected and observed

--- a/src/db.rs
+++ b/src/db.rs
@@ -294,6 +294,23 @@ impl Store {
             );
             CREATE INDEX IF NOT EXISTS idx_validations_changeset ON validations(changeset_id, run_at);
 
+            -- This is the table acceptance actually reads, so it needs at least
+            -- the protection the audit tables have. A row is written once, in
+            -- the same transaction as its authoritative attempt, and is never
+            -- updated or deleted afterwards.
+            CREATE TRIGGER IF NOT EXISTS validations_no_update
+            BEFORE UPDATE ON validations
+            BEGIN SELECT RAISE(ABORT, 'validations are append-only'); END;
+
+            CREATE TRIGGER IF NOT EXISTS validations_no_delete
+            BEFORE DELETE ON validations
+            BEGIN SELECT RAISE(ABORT, 'validations are append-only'); END;
+
+            CREATE TRIGGER IF NOT EXISTS validations_no_replace
+            BEFORE INSERT ON validations
+            WHEN EXISTS(SELECT 1 FROM validations WHERE id = NEW.id)
+            BEGIN SELECT RAISE(ABORT, 'validations are append-only'); END;
+
             CREATE TABLE IF NOT EXISTS validation_attempts (
                 id TEXT PRIMARY KEY,
                 changeset_id TEXT NOT NULL REFERENCES changesets(id),
@@ -1476,6 +1493,66 @@ mod schema_repair_tests {
             )
             .expect("read back");
         assert_eq!(explanation, "original");
+    }
+
+    /// Acceptance reads `validations`, so it must be at least as hard to forge
+    /// as the audit tables. Before this it was the only one of the four with no
+    /// append-only guard at all.
+    #[test]
+    fn the_acceptance_gate_projection_is_append_only() {
+        let store = Store::in_memory().expect("open store");
+        let conn = store.lock().expect("lock");
+        seed_intents(&conn);
+        conn.execute(
+            "INSERT INTO changesets(id, agent_id, task_id, intent_id, summary, files_json,
+             symbols_json, contracts_json, dependencies_json, tests_json, decisions_json,
+             provenance_json, worktree, git_ref, base_ref, fingerprint, status, created_at,
+             updated_at)
+             VALUES('chg_a', 'agt_x', 'tsk_x', 'int_a', 's', '[]', '[]', '[]', '[]', '[]', '[]',
+                    '{}', NULL, NULL, NULL, 'sha256:aaa', 'PROVISIONAL',
+                    '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')",
+            [],
+        )
+        .expect("seed changeset");
+        conn.execute(
+            "INSERT INTO validations(id, changeset_id, command_json, passed, exit_code, stdout,
+             stderr, duration_ms, fingerprint, run_at)
+             VALUES('val_a', 'chg_a', '[\"true\"]', 0, 1, '', '', 5, 'sha256:aaa',
+                    '2026-01-01T00:00:00Z')",
+            [],
+        )
+        .expect("seed validation");
+
+        // Each of these is a way to turn a failing gate into a passing one.
+        assert!(
+            conn.execute("UPDATE validations SET passed = 1 WHERE id = 'val_a'", [])
+                .is_err(),
+            "a recorded validation must not be rewritten"
+        );
+        assert!(
+            conn.execute("DELETE FROM validations WHERE id = 'val_a'", [])
+                .is_err(),
+            "a recorded validation must not be removed"
+        );
+        assert!(
+            conn.execute(
+                "INSERT OR REPLACE INTO validations(id, changeset_id, command_json, passed,
+                 exit_code, stdout, stderr, duration_ms, fingerprint, run_at)
+                 VALUES('val_a', 'chg_a', '[\"true\"]', 1, 0, '', '', 5, 'sha256:aaa',
+                        '2026-01-01T00:00:00Z')",
+                [],
+            )
+            .is_err(),
+            "REPLACE must not overwrite a recorded validation"
+        );
+        let passed: i64 = conn
+            .query_row(
+                "SELECT passed FROM validations WHERE id = 'val_a'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("read back");
+        assert_eq!(passed, 0, "the failing result must survive every attempt");
     }
 
     #[test]


### PR DESCRIPTION
The two MEDIUM findings from the v0.3.0 review that were worth closing before a release. Both are small, and both are about the same thing: making the code match the guarantees the docs imply.

## The acceptance gate read the one unprotected table

v0.3.0 added append-only triggers to `validation_attempts`, `conflict_detections`, and `events`. It did not add them to `validations`, which is the table `accept_changeset` actually queries for a passing result at the current fingerprint. So the audit tables were hardened while the decision table was left open: a rewritten, deleted, or replaced row there flips a failing gate to passing, and every audit table still looks intact afterwards.

`validations` is insert-only in production code (one write site in `service.rs`, no update or delete anywhere), so the guards cost nothing behaviourally. It now has the same three triggers as the others, including the `BEFORE INSERT` id-reuse guard so `INSERT OR REPLACE` cannot bypass them from a connection that has not enabled `recursive_triggers`.

New test asserts all three attack shapes against a recorded failing validation and checks the `passed = 0` result survives each one.

## `authoritative` promised more than it delivers

The word appears throughout the docs without a definition, and its actual meaning is narrower than a reader would assume. It asserts that the worktree fingerprint was identical immediately before and immediately after the command, and that the ChangeSet revision and lifecycle state did not change while it ran. It does **not** assert that the command observed the fingerprinted tree: Foremerge samples the endpoints rather than watching the worktree during execution, so a command that mutates tracked files, tests the mutated tree, and restores it before exiting is recorded as authoritative.

`docs/limitations.md` now states this plainly, including that named checks over MCP narrow it (an agent picks which registered check runs, never its argument vector) while CLI and HTTP callers supply the command directly and are trusted accordingly. `docs/state-model.md` carries the short version next to the freshness rules and links across.

No behaviour change for this half. It is a claim the project was making that its implementation does not support, which is exactly the kind of thing the honest-limitations posture exists to catch.

## Verification

- `make verify`, `make msrv` on pinned 1.85, and `make benchmarks` all green (65 unit, 50 e2e).
- External dogfood harness 8/8 against a GPTree sandbox clone.
- Upgrade check: a store built by the released v0.3.0 binary with a validation already recorded opens cleanly under the new triggers and its event chain still verifies.