### PR TITLE
Close the event replace gap, widen duplicate repair, and cut 0.3.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,31 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # A tag that disagrees with the crate version would publish assets labelled
+  # one version containing a binary and an API contract that report another.
+  verify-version:
+    name: Tag matches crate version
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Compare tag with Cargo package version
+        run: |
+          crate=$(cargo metadata --no-deps --format-version 1 \
+            | python3 -c 'import json,sys; print(json.load(sys.stdin)["packages"][0]["version"])')
+          if [ "$GITHUB_REF_NAME" != "v$crate" ]; then
+            echo "tag $GITHUB_REF_NAME does not match crate version $crate" >&2
+            exit 1
+          fi
+          echo "tag $GITHUB_REF_NAME matches crate version $crate"
+
   test:
     name: Test ${{ matrix.os }}
+    needs: verify-version
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,10 @@ on:
   push:
     tags: ["v*"]
 
+# Read by default. Only the publish job may write, and only after the release
+# environment's approval gate is satisfied.
 permissions:
-  contents: write
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -134,6 +136,11 @@ jobs:
     name: Publish GitHub release
     needs: build
     runs-on: ubuntu-latest
+    # Requires an approval in the protected `release` environment, so a pushed
+    # tag builds and tests but cannot publish on its own.
+    environment: release
+    permissions:
+      contents: write
     timeout-minutes: 10
     steps:
       - name: Check out source

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ changes when they are called out here with a migration note.
 
 ## [0.3.1] - 2026-08-24
 
+Opening a store with this release migrates it to database schema 4. The upgrade
+is automatic and one way: it repairs the duplicate detection rows that earlier
+schemas could write, completes any partially written scope projection, and
+stamps the new version. Schema 4 sweeps stores stamped 1, 2, or 3, because an
+interrupted upgrade could leave duplicates behind any of them. Observations that
+genuinely differ are preserved. An older Foremerge build will refuse to open a
+schema 4 store rather than migrate it backwards.
+
+### Added
+
+- The release workflow refuses a tag that disagrees with the crate version, and
+  publication requires an approval in the protected `release` environment.
+
 ### Fixed
 
 - Validation now refuses to start when excluded generated files are already
@@ -32,13 +45,13 @@ changes when they are called out here with a migration note.
   previously left the `intent_scopes` projection partially written, and the
   per-intent skip guard then treated the partial intent as done forever, so the
   intent silently disappeared from scope queries with no error. The migration is
-  now all or nothing, and schema 3 reprojects every intent once to repair stores
-  already damaged this way.
+  now all or nothing, and the upgrade reprojects every intent once to repair
+  stores already damaged this way.
 - One-time backfills are gated on the stored schema version instead of running
   on every `Store::open`. Schema 2 re-ran them on every process start, which
   minted a duplicate synthesized detection for every conflict that already had a
   native one: two immutable observations for a single detection, and an
-  occurrence table that disagreed with the event log. Schema 3 removes those
+  occurrence table that disagreed with the event log. The upgrade removes those
   duplicates on first open, keeping genuine legacy rows where they are a
   conflict's only observation. Gating also removes a full rescan of `intents`,
   `conflicts`, and `validations` from every CLI invocation.
@@ -56,10 +69,22 @@ changes when they are called out here with a migration note.
   is refused with `UNSUPPORTED_SCHEMA` instead of being migrated backwards and
   restamped. A malformed value is reported as `CORRUPT_STORE` rather than
   silently reading as zero, which would have rerun every one-time backfill.
-- The schema 3 repair removes only a byte-identical duplicate observation. The
-  previous condition deleted any synthesized row whenever a native one existed
+- The duplicate repair removes only a byte-identical duplicate observation. An
+  earlier condition deleted any synthesized row whenever a native one existed
   for the same conflict, which destroyed a genuine earlier observation that a
   later redetection happened to follow.
+- The event log rejects `INSERT OR REPLACE`. It had guards against `UPDATE` and
+  `DELETE`, but a replace deletes the conflicting row first, and that delete
+  only fires the guard when `recursive_triggers` is on, which is a
+  per-connection setting any other SQLite client can ignore. Unlike the other
+  record tables, `events` has three unique keys, so the guard checks `seq`,
+  `event_id`, and `event_hash`.
+- The duplicate repair now sweeps every store below the current schema rather
+  than only those stamped with the schema that introduced the duplicates. That
+  earlier migration was not transactional, so an upgrade interrupted between the
+  backfill and the version stamp left duplicates behind an older stamp, and a
+  repair keyed to one exact stamp could restamp such a store with its duplicates
+  intact.
 - The documented daemon shutdown grace is now a process-exit bound. The daemon
   builds and owns its Tokio runtime, so when the 30 second HTTP grace expires it
   abandons the remaining requests (terminating the validation subprocess trees

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ changes when they are called out here with a migration note.
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-08-24
+
 ### Fixed
 
 - Validation now refuses to start when excluded generated files are already
@@ -198,7 +200,8 @@ changes when they are called out here with a migration note.
 - Apache-2.0 licensing, contribution and security policies, CI, release checks,
   limitations, roadmap, and a reproducible benchmark specification.
 
-[Unreleased]: https://github.com/naw103/foremerge/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/naw103/foremerge/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/naw103/foremerge/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/naw103/foremerge/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/naw103/foremerge/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/naw103/foremerge/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,7 +410,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foremerge"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "foremerge"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 rust-version = "1.85"
 description = "The open-source coordination protocol for autonomous software engineering"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ above Git. Agents keep isolated worktrees while sharing intent, semantic
 claims, dependencies, provisional ChangeSets, decisions, validation, and
 provenance.
 
-> **Status:** Foremerge `0.3.0` is a pre-1.0, local-first MVP. The CLI, JSON API,
+> **Status:** Foremerge `0.3.1` is a pre-1.0, local-first MVP. The CLI, JSON API,
 > MCP server, SQLite store, deterministic conflict detector, and
 > verification-gated lifecycle are implemented. Public schemas may still
 > change. Shared multi-machine mode and published benchmark results do not yet

--- a/README.md
+++ b/README.md
@@ -46,6 +46,32 @@ command uses the shown `jq` filter; output is abridged for readability._
 
 ## Quickstart: first conflict in under five minutes
 
+### Let your coding agent do it
+
+Paste this into Claude Code, Codex, or Cursor from inside the repository you
+want to coordinate:
+
+```text
+Set up Foremerge in this repository so we can coordinate parallel agents.
+
+1. Install it:      curl -fsSL https://naw103.github.io/foremerge/install.sh | sh
+2. Initialize:      foremerge init
+3. Wire this client and any others in use: foremerge setup all
+4. Register the check I should be validated against, for example:
+                    foremerge checks set test -- cargo test --all-targets
+5. Confirm:         foremerge doctor --client all
+
+Then read the Foremerge skill that step 3 installed for this client and follow
+it from now on: publish your intent with semantic scopes before editing, claim
+the scope, and check for conflicts before you start.
+```
+
+Adjust step 4 to whatever this repository's real test command is. Step 3 asks
+the client to enable an MCP server, so it will prompt you before doing so, and
+the Codex registration is user level and points at one repository at a time.
+
+### Or do it yourself
+
 You need a recent Git and `jq`. Install a prebuilt, checksum-verified release
 binary (macOS and Linux; the script installs to `~/.local/bin`):
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -142,6 +142,12 @@ repository-local `foremerge` runtime directory reset; they are not an upgrade
 compatibility promise. Tagged-release schema changes will carry migrations and
 changelog guidance.
 
+Migrations run automatically on open, in one transaction, and only forward. A
+build refuses to open a store stamped with a schema newer than it understands
+rather than migrating it backwards, so upgrading one worktree's binary while
+another still runs an older one will make the older one fail closed. Upgrade
+every agent on a shared repository together.
+
 ## What Foremerge does not replace
 
 - code review and architecture ownership;

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Foremerge local JSON API
-  version: 0.3.0
+  version: 0.3.1
   description: >-
     Local-first semantic coordination API above Git. Successful responses use
     an ok/data envelope. All versioned routes require bearer authentication when

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,7 +4,7 @@ Foremerge is building the smallest credible coordination layer above Git. The
 roadmap is ordered by evidence and interoperability, not dates. Items are plans,
 not promises, unless a release note marks them shipped.
 
-## Shipped local proof (through 0.3.0)
+## Shipped local proof (through 0.3.1)
 
 The current local release establishes the core thesis on one developer machine:
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -11,7 +11,7 @@ use std::sync::{Arc, Mutex, MutexGuard, TryLockError};
 use std::time::Duration;
 use uuid::Uuid;
 
-const DATABASE_SCHEMA_VERSION: i64 = 3;
+const DATABASE_SCHEMA_VERSION: i64 = 4;
 // Event hashing is versioned independently from the mutable SQLite projection
 // schema. A database migration must not silently change the hash material for
 // otherwise identical events.
@@ -468,6 +468,22 @@ impl Store {
             CREATE TRIGGER IF NOT EXISTS events_no_delete
             BEFORE DELETE ON events
             BEGIN SELECT RAISE(ABORT, 'event log is append-only'); END;
+
+            -- INSERT OR REPLACE resolves against ANY unique key, deleting the
+            -- conflicting row, and that delete only fires the trigger above
+            -- when recursive_triggers is on, which is per-connection. This
+            -- table has three unique keys, so all three must be checked. On an
+            -- ordinary append NEW.seq is null (AUTOINCREMENT assigns it after
+            -- this trigger) and the other two are fresh, so nothing matches.
+            CREATE TRIGGER IF NOT EXISTS events_no_replace
+            BEFORE INSERT ON events
+            WHEN EXISTS(
+                SELECT 1 FROM events
+                WHERE seq = NEW.seq
+                   OR event_id = NEW.event_id
+                   OR event_hash = NEW.event_hash
+            )
+            BEGIN SELECT RAISE(ABORT, 'event log is append-only'); END;
             "#,
         )?;
         // The schema version the store was last written with. Absent means a
@@ -648,13 +664,19 @@ impl Store {
                 [],
             )?;
         }
-        if stored_version == 2 {
+        if stored_version < 4 {
             // Schema 2 minted a synthesized detection for every conflict on
             // every open, so conflicts that already had a native observation
             // carry a duplicate. Remove only those duplicates: a legacy row is
             // genuine when it is the conflict's sole observation. The
             // append-only trigger is dropped for the length of this repair and
             // restored inside the same transaction.
+            //
+            // Every store below schema 4 is swept, not just those stamped 2.
+            // Schema 2's migration was not transactional, so an upgrade killed
+            // between the backfill and the stamp left duplicates behind a
+            // version 1 stamp, and schema 3 repaired only stores stamped 2, so
+            // it could stamp such a store as 3 with its duplicates intact.
             conn.execute_batch("DROP TRIGGER IF EXISTS conflict_detections_no_delete;")?;
             // Only a byte-identical twin is a phantom. A legacy row that
             // differs from every native row is a genuine earlier observation,
@@ -1553,6 +1575,142 @@ mod schema_repair_tests {
             )
             .expect("read back");
         assert_eq!(passed, 0, "the failing result must survive every attempt");
+    }
+
+    /// Schema 2's migration was not transactional, so an interrupted upgrade
+    /// could leave duplicates behind a version 1 stamp, and the schema 3 repair
+    /// only swept stores stamped 2. Both that store and one already stamped 3
+    /// with duplicates intact must still be repaired.
+    #[test]
+    fn duplicates_are_repaired_from_any_pre_schema_4_stamp() {
+        for stamp in ["1", "3"] {
+            let store = Store::in_memory().expect("open store");
+            let conn = store.lock().expect("lock");
+            seed_intents(&conn);
+            seed_conflict(&conn, "cfl_dup", "2026-03-01T00:00:00Z");
+            seed_detection(
+                &conn,
+                "dtn_native_dup",
+                "cfl_dup",
+                "same",
+                "2026-03-01T00:00:00Z",
+            );
+            seed_detection(
+                &conn,
+                "dtn_legacy_cfl_dup",
+                "cfl_dup",
+                "same",
+                "2026-03-01T00:00:00Z",
+            );
+            seed_conflict(&conn, "cfl_real", "2026-01-01T00:00:00Z");
+            seed_detection(
+                &conn,
+                "dtn_legacy_cfl_real",
+                "cfl_real",
+                "early",
+                "2026-01-01T00:00:00Z",
+            );
+            seed_detection(
+                &conn,
+                "dtn_native_real",
+                "cfl_real",
+                "later",
+                "2026-02-01T00:00:00Z",
+            );
+            conn.execute(
+                "UPDATE meta SET value = ?1 WHERE key = 'schema_version'",
+                [stamp],
+            )
+            .expect("stamp an earlier schema");
+
+            Store::migrate(&conn).expect("repair migration");
+
+            assert_eq!(
+                detection_ids(&conn, "cfl_dup"),
+                vec!["dtn_native_dup".to_string()],
+                "the identical twin must be removed from a store stamped {stamp}"
+            );
+            assert_eq!(
+                detection_ids(&conn, "cfl_real").len(),
+                2,
+                "a genuine earlier observation must survive in a store stamped {stamp}"
+            );
+        }
+    }
+
+    /// The event log has three unique keys, so a REPLACE resolving against any
+    /// one of them would delete a row without firing the delete trigger on a
+    /// connection that has not enabled recursive_triggers.
+    #[test]
+    fn events_reject_replacement_through_every_unique_key() {
+        let store = Store::in_memory().expect("open store");
+        let conn = store.lock().expect("lock");
+        conn.execute_batch("PRAGMA recursive_triggers = OFF;")
+            .expect("simulate an outside connection");
+        let tx = conn.unchecked_transaction().expect("transaction");
+        Store::append_event(
+            &tx,
+            "agent.registered",
+            "Agent",
+            "agt_x",
+            None,
+            &json!({ "original": true }),
+        )
+        .expect("append an event");
+        tx.commit().expect("commit the event");
+        let (seq, event_id, event_hash): (i64, String, String) = conn
+            .query_row(
+                "SELECT seq, event_id, event_hash FROM events ORDER BY seq DESC LIMIT 1",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("read the event back");
+
+        // Each of these collides on a different unique key.
+        let collisions = [
+            (
+                seq.to_string(),
+                "evt_other".to_string(),
+                "hash_other".to_string(),
+            ),
+            (
+                "999".to_string(),
+                event_id.clone(),
+                "hash_other".to_string(),
+            ),
+            (
+                "999".to_string(),
+                "evt_other".to_string(),
+                event_hash.clone(),
+            ),
+        ];
+        for (seq_value, id_value, hash_value) in collisions {
+            let replaced = conn.execute(
+                "INSERT OR REPLACE INTO events(seq, event_id, schema_version, event_type,
+                 entity_type, entity_id, agent_id, payload_json, created_at, prev_hash, event_hash)
+                 VALUES(?1, ?2, 1, 'agent.registered', 'Agent', 'agt_x', NULL,
+                        '{\"tampered\":true}', '2026-01-01T00:00:00Z', 'GENESIS', ?3)",
+                params![seq_value, id_value, hash_value],
+            );
+            assert!(
+                replaced.is_err(),
+                "REPLACE colliding on ({seq_value}, {id_value}, {hash_value}) must be rejected"
+            );
+        }
+        let payload: String = conn
+            .query_row(
+                "SELECT payload_json FROM events WHERE seq = ?1",
+                [seq],
+                |row| row.get(0),
+            )
+            .expect("read payload");
+        assert!(
+            payload.contains("original"),
+            "the original event must survive"
+        );
+        // verify_event_chain takes the store lock, so release this guard first.
+        drop(conn);
+        assert!(store.verify_event_chain().expect("verify"), "chain intact");
     }
 
     #[test]


### PR DESCRIPTION
The three findings from the latest review, all reproduced against `main` before fixing.

## 1. Event rows were replaceable from an outside connection (P1)

`events` had `no_update` and `no_delete` but no guard against `INSERT OR REPLACE`, and `recursive_triggers` is per-connection, so a default `sqlite3` client could replace a row and rewrite its payload and hash. The chain audit reported `valid:false` afterwards, which is good detection, but the append-only preservation guarantee had already failed.

`events` differs from those tables in having **three** unique keys (`seq`, `event_id`, `event_hash`), and a REPLACE resolves against any of them, so the guard checks all three. On an ordinary append `NEW.seq` is null because AUTOINCREMENT assigns after the trigger, and the other two are fresh, so nothing matches.

Verified against a real store from an external `sqlite3` connection with default pragmas: all three collision shapes now return `event log is append-only (19)`, zero tampered rows land, and the chain still verifies.

## 2. Interrupted schema 2 upgrades stamped version 1 were never repaired (P2)

Schema 2's migration was not transactional, so an upgrade killed between the detection backfill and the version stamp left duplicates behind a version 1 stamp. The schema 3 repair ran only when the stamp was exactly 2, so such a store could be stamped 3 with its duplicates intact and never swept again.

Schema is now 4 and the repair sweeps every store below 4, which covers stores stamped 1, 2, and any already stamped 3 by current `main`. Observations that genuinely differ are still preserved. Fixtures cover both the version 1 and version 3 starting stamps alongside the existing exact-duplicate and genuine-redetection cases.

## 3. The candidate still identified itself as 0.3.0 (P1 release)

Tagging `v0.3.1` would have produced assets labelled 0.3.1 containing a binary and an OpenAPI contract reporting 0.3.0. Updated: `Cargo.toml`, `Cargo.lock`, the README status line, `docs/openapi.yaml`, and a dated `[0.3.1]` CHANGELOG section with comparison links. Historical ADR and v0.3.0 references are untouched.

The release workflow now has a `verify-version` job that compares the tag against the crate version from `cargo metadata` and fails the release before anything builds. Every other job depends on it, so this class of mismatch cannot ship again.

## Verification

`make verify`, `make msrv` on pinned 1.85, and `make benchmarks` all green (67 unit, 50 e2e). `cargo package --locked` verifies clean. External dogfood harness 8/8 against a GPTree sandbox clone. Binary, crate, lockfile, and OpenAPI all report 0.3.1.