### PR TITLE
Explain foremerge mcp when a person runs it in a terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ changes when they are called out here with a migration note.
 
 ## [Unreleased]
 
+### Added
+
+- `foremerge mcp` explains itself when it is run in a terminal. It is a stdio
+  protocol server, so a person who runs it sees an apparently idle process, and
+  typing a tool name such as `list_agents` returns only a parse error. It now
+  prints guidance to stderr on startup, and answers a bare tool name with the
+  equivalent JSON-RPC line. Both are suppressed when stdin is a pipe, so client
+  sessions are byte for byte unchanged.
+
 ## [0.3.1] - 2026-08-24
 
 Opening a store with this release migrates it to database schema 4. The upgrade

--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -390,6 +390,13 @@ For protocol debugging, run `foremerge mcp` directly and send one compact JSON
 object per line. A real MCP client should begin with `initialize`, followed by
 the initialized notification and `tools/list`.
 
+Tool names such as `list_agents` are not commands, so typing one on its own
+returns a `-32700` parse error. When stdin is a terminal the server prints
+guidance to stderr, and typing a bare tool name prints the equivalent JSON-RPC
+line. That guidance is suppressed when stdin is a pipe, so client sessions are
+unaffected. To read coordination state as a person, use the CLI instead, for
+example `foremerge status` or `foremerge agent list`.
+
 The server currently negotiates MCP protocol version `2026-07-28` when the
 client requests it and otherwise falls back to `2025-11-25`. It also responds to
 `ping` and `server/discover`. Notifications have no response.

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -2,13 +2,42 @@ use crate::model::*;
 use crate::{Foremerge, checks};
 use serde::Deserialize;
 use serde_json::{Value, json};
+use std::io::IsTerminal;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
 const CURRENT_PROTOCOL: &str = "2026-07-28";
 const LEGACY_PROTOCOL: &str = "2025-11-25";
 
+/// Shown once when a person runs `foremerge mcp` in a terminal.
+///
+/// Coding agents launch this command with a pipe on stdin, so they never see
+/// this. It goes to stderr because stdout carries the protocol.
+const INTERACTIVE_NOTICE: &str = "\
+foremerge mcp is a machine interface. It speaks JSON-RPC over stdin and stdout and is
+meant to be launched by a coding agent, not typed at directly. It is now waiting for a
+message on stdin, which is normal.
+
+To wire it into Claude Code, Codex, or Cursor instead:
+
+    foremerge setup all
+
+To read coordination state yourself, use the ordinary CLI:
+
+    foremerge status
+    foremerge agent list
+    foremerge --help
+
+Press Ctrl-C to exit.
+";
+
 pub async fn run_stdio(service: Foremerge) -> anyhow::Result<()> {
     let stdin = tokio::io::stdin();
+    // A terminal on stdin means a person is here, not a client. Real clients
+    // get byte-identical behaviour because their stdin is a pipe.
+    let interactive = std::io::stdin().is_terminal();
+    if interactive {
+        eprint!("{INTERACTIVE_NOTICE}");
+    }
     let mut lines = BufReader::new(stdin).lines();
     let mut stdout = tokio::io::stdout();
     while let Some(line) = lines.next_line().await? {
@@ -17,11 +46,16 @@ pub async fn run_stdio(service: Foremerge) -> anyhow::Result<()> {
         }
         let response = match serde_json::from_str::<Value>(&line) {
             Ok(message) => handle_message(&service, message).await,
-            Err(error) => Some(jsonrpc_error(
-                Value::Null,
-                -32700,
-                &format!("parse error: {error}"),
-            )),
+            Err(error) => {
+                if interactive {
+                    eprintln!("\n{}", interactive_parse_hint(line.trim()));
+                }
+                Some(jsonrpc_error(
+                    Value::Null,
+                    -32700,
+                    &format!("parse error: {error}"),
+                ))
+            }
         };
         if let Some(response) = response {
             let mut encoded = serde_json::to_vec(&response)?;
@@ -31,6 +65,35 @@ pub async fn run_stdio(service: Foremerge) -> anyhow::Result<()> {
         }
     }
     Ok(())
+}
+
+/// Explains a parse failure to a person typing at the terminal.
+///
+/// Typing a bare tool name is the likely mistake, because tool names are what
+/// the agent-facing documentation shows, so that case gets the exact line to
+/// paste. The catalog is consulted rather than a hand-written list so the hint
+/// cannot drift as tools are added.
+fn interactive_parse_hint(input: &str) -> String {
+    let known = tool_catalog()
+        .iter()
+        .any(|tool| tool.get("name").and_then(Value::as_str) == Some(input));
+    if known {
+        let call = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": { "name": input, "arguments": {} }
+        });
+        return format!(
+            "\"{input}\" is a real tool, but this interface reads JSON-RPC rather than bare\n\
+             tool names. The equivalent line to paste is:\n\n    {call}\n\n\
+             Reading the same state with `foremerge status` in another terminal is easier."
+        );
+    }
+    format!(
+        "This interface reads one JSON-RPC message per line, so \"{input}\" was not understood.\n\
+         If you meant to use Foremerge yourself, run `foremerge --help` instead."
+    )
 }
 
 pub async fn handle_message(service: &Foremerge, message: Value) -> Option<Value> {
@@ -719,6 +782,45 @@ pub fn tool_catalog() -> Vec<Value> {
 mod tests {
     use super::*;
     use crate::Store;
+
+    #[test]
+    fn a_bare_tool_name_is_answered_with_the_line_that_would_have_worked() {
+        let hint = interactive_parse_hint("list_agents");
+        // The pasteable line has to be a real request, not prose about one.
+        let line = hint
+            .lines()
+            .find(|line| line.trim_start().starts_with('{'))
+            .expect("hint offers a JSON-RPC line");
+        let parsed: Value = serde_json::from_str(line.trim()).expect("the line is valid JSON");
+        assert_eq!(parsed["method"], "tools/call");
+        assert_eq!(parsed["params"]["name"], "list_agents");
+    }
+
+    #[test]
+    fn every_catalog_tool_is_recognised_by_the_hint() {
+        // Guards against the hint drifting as tools are added or renamed.
+        for tool in tool_catalog() {
+            let name = tool["name"].as_str().unwrap();
+            assert!(
+                interactive_parse_hint(name).contains("is a real tool"),
+                "{name} was not recognised"
+            );
+        }
+    }
+
+    #[test]
+    fn unrecognised_input_is_pointed_at_the_command_line_interface() {
+        let hint = interactive_parse_hint("hello");
+        assert!(hint.contains("foremerge --help"));
+        assert!(!hint.contains("is a real tool"));
+    }
+
+    #[test]
+    fn terminal_guidance_carries_no_em_dashes() {
+        assert!(!INTERACTIVE_NOTICE.contains('\u{2014}'));
+        assert!(!interactive_parse_hint("list_agents").contains('\u{2014}'));
+        assert!(!interactive_parse_hint("hello").contains('\u{2014}'));
+    }
 
     #[tokio::test]
     async fn lists_the_complete_lifecycle_tools_in_deterministic_order() {

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -74,10 +74,32 @@ pub async fn run_stdio(service: Foremerge) -> anyhow::Result<()> {
 /// paste. The catalog is consulted rather than a hand-written list so the hint
 /// cannot drift as tools are added.
 fn interactive_parse_hint(input: &str) -> String {
-    let known = tool_catalog()
-        .iter()
-        .any(|tool| tool.get("name").and_then(Value::as_str) == Some(input));
-    if known {
+    let Some(tool) = tool_catalog()
+        .into_iter()
+        .find(|tool| tool.get("name").and_then(Value::as_str) == Some(input))
+    else {
+        return format!(
+            "This interface reads one JSON-RPC message per line, so \"{input}\" was not understood.\n\
+             If you meant to use Foremerge yourself, run `foremerge --help` instead."
+        );
+    };
+
+    // Most tools take arguments, so an empty-argument call would be rejected.
+    // Only offer a line to paste when that line actually works, which means
+    // the tool accepts no input at all. An empty `required` list is not enough:
+    // `check_conflicts` declares none yet still demands an intent at runtime.
+    let schema = tool.get("inputSchema");
+    let required: Vec<&str> = schema
+        .and_then(|schema| schema.get("required"))
+        .and_then(Value::as_array)
+        .map(|names| names.iter().filter_map(Value::as_str).collect())
+        .unwrap_or_default();
+    let takes_no_input = schema
+        .and_then(|schema| schema.get("properties"))
+        .and_then(Value::as_object)
+        .is_some_and(|properties| properties.is_empty());
+
+    if takes_no_input {
         let call = json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -90,9 +112,24 @@ fn interactive_parse_hint(input: &str) -> String {
              Reading the same state with `foremerge status` in another terminal is easier."
         );
     }
+
+    let schema_request = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/list",
+        "params": {}
+    });
+    let needs = if required.is_empty() {
+        "this one takes arguments".to_string()
+    } else {
+        format!("this one needs arguments: {}", required.join(", "))
+    };
     format!(
-        "This interface reads one JSON-RPC message per line, so \"{input}\" was not understood.\n\
-         If you meant to use Foremerge yourself, run `foremerge --help` instead."
+        "\"{input}\" is a real tool, but this interface reads JSON-RPC rather than bare\n\
+         tool names, and {needs}.\n\n\
+         To see its full schema, paste:\n\n    {schema_request}\n\n\
+         Driving the lifecycle by hand is rarely what you want. `foremerge --help` exposes\n\
+         the same operations as ordinary commands."
     )
 }
 
@@ -806,6 +843,65 @@ mod tests {
                 "{name} was not recognised"
             );
         }
+    }
+
+    /// The previous version of this test only checked that the offered line was
+    /// syntactically valid JSON, which it was, while being rejected at runtime
+    /// for every tool that takes required arguments. Execute it instead.
+    #[tokio::test]
+    async fn every_line_the_hint_offers_actually_succeeds() {
+        let service = Foremerge::new(Store::in_memory().unwrap());
+        for tool in tool_catalog() {
+            let name = tool["name"].as_str().unwrap().to_string();
+            let required = tool
+                .get("inputSchema")
+                .and_then(|schema| schema.get("required"))
+                .and_then(Value::as_array)
+                .map(|names| names.len())
+                .unwrap_or(0);
+
+            let hint = interactive_parse_hint(&name);
+            let line = hint
+                .lines()
+                .find(|line| line.trim_start().starts_with('{'))
+                .unwrap_or_else(|| panic!("{name}: hint offered no request at all"));
+            let message: Value =
+                serde_json::from_str(line.trim()).expect("the offered line is valid JSON");
+
+            // A tools/call may only be offered when it needs no arguments.
+            if message["method"] == "tools/call" {
+                assert_eq!(
+                    required, 0,
+                    "{name} requires {required} argument(s) but was offered as a bare call"
+                );
+            }
+
+            let response = handle_message(&service, message)
+                .await
+                .unwrap_or_else(|| panic!("{name}: no response"));
+            assert!(
+                response.get("error").is_none(),
+                "{name}: offered line returned a protocol error: {response}"
+            );
+            assert!(
+                !response["result"]["isError"].as_bool().unwrap_or(false),
+                "{name}: offered line failed at runtime: {}",
+                response["result"]["structuredContent"]
+            );
+        }
+    }
+
+    #[test]
+    fn tools_needing_arguments_name_them_instead_of_offering_a_broken_call() {
+        // publish_intent requires agent_id, task and summary.
+        let hint = interactive_parse_hint("publish_intent");
+        for field in ["agent_id", "task", "summary"] {
+            assert!(hint.contains(field), "hint should name {field}:\n{hint}");
+        }
+        assert!(
+            !hint.contains("tools/call"),
+            "a tool needing arguments must not be offered as a call:\n{hint}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What this fixes

Running `foremerge mcp` by hand and typing `list_agents` returns:

```
{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"parse error: expected value at line 1 column 1"}}
```

Nothing is broken. It is a stdio protocol server waiting for JSON-RPC. But the failure mode is unhelpful: the server starts silently, so it looks like an idle process, and `list_agents` is a real tool name that the agent-facing docs show, so typing it is the natural first thing to try.

## What changed

When stdin is a terminal, the server prints to stderr what it is and how to reach the same state through the CLI. Typing a bare tool name prints the JSON-RPC line that would have worked. The hint consults `tool_catalog()` rather than a hand-written list, so it cannot drift as tools are added or renamed, and a test asserts every catalog tool is recognised.

## Client behaviour is unchanged

Both outputs go to stderr and are gated on `IsTerminal`. A client's stdin is a pipe, so it sees exactly what it saw before. Verified:

- piped: stderr empty, same JSON on stdout, `tools/call` still returns the agent list
- pty (via `expect`): guidance prints, and the suggested line is valid and returns real data

`make verify` and `make msrv` both pass.