### PR TITLE
Add a three-step diagram and a plain-English "How it works" to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,13 @@ Say you have two AI agents working on the same project at the same time. Each
 one gets its own copy of the code, so they never fight over files. Both finish.
 Both look correct. Then you find they undid each other's work.
 
-Git cannot warn you about that. Git notices a conflict only when two changes
-touch the same lines of the same file. If one agent deletes the function
-another agent is busy extending, those are different lines, so Git merges both
-happily and the result is broken.
+Git cannot warn you about that, because Git compares text and not intent. It
+will stop you when two agents edit the same part of the same file. What it
+cannot see is two edits that are each perfectly reasonable on their own and
+land in different files. If one agent moves every caller onto a new
+`StripePaymentService` while another adds PayPal support to the old
+`PaymentService`, nothing overlaps, so Git merges both without complaint and
+the PayPal work is left stranded on a class nothing calls any more.
 
 Foremerge fixes this by having agents announce what they are about to do,
 before they do it.

--- a/README.md
+++ b/README.md
@@ -11,11 +11,47 @@ above Git. Agents keep isolated worktrees while sharing intent, semantic
 claims, dependencies, provisional ChangeSets, decisions, validation, and
 provenance.
 
+| [**Tell your agent to install it**](#quickstart-first-conflict-in-under-five-minutes) | → | **Done** | → | **No more silent collisions across worktrees** |
+| :---: | :---: | :---: | :---: | :---: |
+| Paste one line into Claude Code, Codex, or Cursor | | It installs Foremerge and wires itself up | | Every agent sees what the others are about to change, before they change it |
+
 > **Status:** Foremerge `0.3.1` is a pre-1.0, local-first MVP. The CLI, JSON API,
 > MCP server, SQLite store, deterministic conflict detector, and
 > verification-gated lifecycle are implemented. Public schemas may still
 > change. Shared multi-machine mode and published benchmark results do not yet
 > exist.
+
+## How it works
+
+Say you have two AI agents working on the same project at the same time. Each
+one gets its own copy of the code, so they never fight over files. Both finish.
+Both look correct. Then you find they undid each other's work.
+
+Git cannot warn you about that. Git notices a conflict only when two changes
+touch the same lines of the same file. If one agent deletes the function
+another agent is busy extending, those are different lines, so Git merges both
+happily and the result is broken.
+
+Foremerge fixes this by having agents announce what they are about to do,
+before they do it.
+
+1. **Each agent says what it is about to touch.** Not the code, just the
+   target, like "I am going to change the `sendEmail` function."
+2. **Every agent reads from one shared list.** It is a small database inside
+   your project's `.git` folder, so every agent on your machine sees the same
+   picture, whether it is Claude, Codex, or Cursor.
+3. **If two plans collide, you hear about it right away.** Foremerge names the
+   two agents, explains why their plans clash, and suggests how to split the
+   work. Both worktrees are still clean at that point, so no work has to be
+   thrown away.
+
+Think of it as a shared whiteboard. Before an agent starts, it writes down what
+it is about to work on, and it reads what everyone else already wrote.
+
+Two things Foremerge deliberately does not do. It never locks a file or blocks
+an agent, because a single crashed agent would then stall the whole fleet, so
+the warnings are advisory and you stay in charge. And it never asks a model to
+judge conflicts, so the same inputs always produce the same answer.
 
 ## The conflict Git cannot see yet
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ above Git. Agents keep isolated worktrees while sharing intent, semantic
 claims, dependencies, provisional ChangeSets, decisions, validation, and
 provenance.
 
-| [**Tell your agent to install it**](#quickstart-first-conflict-in-under-five-minutes) | → | **Done** | → | **No more silent collisions across worktrees** |
+| [**Tell your agent to install it**](#quickstart-first-conflict-in-under-five-minutes) | → | **Done** | → | **See collisions before they land** |
 | :---: | :---: | :---: | :---: | :---: |
-| Paste one line into Claude Code, Codex, or Cursor | | It installs Foremerge and wires itself up | | Every agent sees what the others are about to change, before they change it |
+| Paste one line into Claude Code, Codex, or Cursor | | It installs Foremerge and wires itself up | | Every agent sees what the others are about to change, even in separate worktrees |
 
 > **Status:** Foremerge `0.3.1` is a pre-1.0, local-first MVP. The CLI, JSON API,
 > MCP server, SQLite store, deterministic conflict detector, and


### PR DESCRIPTION
Stacked on #7, which is stacked on #6. Merge order: #6, then #7, then this one. Each retargets automatically as its base merges.

## What changed

**A three-step diagram** immediately under the intro, before the status note:

| [**Tell your agent to install it**](#quickstart) | → | **Done** | → | **No more silent collisions across worktrees** |
| :---: | :---: | :---: | :---: | :---: |
| Paste one line into Claude Code, Codex, or Cursor | | It installs Foremerge and wires itself up | | Every agent sees what the others are about to change, before they change it |

The first cell links to the quickstart. Built as a markdown table rather than a mermaid diagram deliberately: this README is published to crates.io, which does not render mermaid, so a mermaid block would appear there as a raw code fence.

**A "How it works" section** written for someone who has never heard of a semantic scope. It explains why Git cannot see the problem, gives the mechanism as three numbered steps, uses a shared whiteboard analogy, and states what Foremerge deliberately does not do (no locks, no model in the detection path).

## One wording change

The third step was requested as "no more conflicts across worktrees". I changed it to "no more silent collisions". Foremerge does not remove conflicts, it surfaces them early, and its output is explicitly advisory rather than a lock. The project's credibility rests on its honest limitations section, so a headline claim it cannot support seemed like the wrong trade.

## Verified

Rendered through GitHub's own `/markdown` API: the table renders as a real `<table>` with the arrows and captions in the right cells, and the install link resolves to `#quickstart-first-conflict-in-under-five-minutes`, matching the heading slug.

No em dashes.