### PR TITLE
Fix the coordination gaps found by dogfooding against real agent runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,37 @@ changes when they are called out here with a migration note.
 
 ## [Unreleased]
 
+Opening a store with this release migrates it to database schema 5. Symbol
+scopes are now normalized, so every canonical form stored under an older schema
+is recomputed: the scope projection is rebuilt from `intents.scopes_json`, which
+is the source of truth and is untouched, and claims are recomputed in place.
+Where normalization makes two live claims on one intent share a scope, the
+longest-lived is kept and the others are released. An older Foremerge build will
+refuse to open a schema 5 store rather than migrate it backwards.
+
 ### Added
+
+- `foremerge work adopt` transfers an intent whose agent has stopped. An agent
+  that died mid-task previously left its intent owned forever by an agent that
+  would never return, so the work could only be duplicated. Adoption is refused
+  while any claim on the intent is still live, so it can never take work from an
+  agent that is merely busy; the expiry of every claim is the evidence that the
+  owner has stopped. The handover records the previous owner and a reason.
+- `foremerge checks policy <strict|advisory>` sets what acceptance requires when
+  Foremerge verified nothing itself. Strict, the default and the previous
+  behaviour, accepts only verified work. Advisory accepts work with nothing to
+  verify, recorded as `UNVERIFIED` with a reason. A check that ran and *failed*
+  is never cleared by policy, because a failure is evidence of breakage rather
+  than an absence of evidence.
+- `foremerge changeset accept --allow-unverified --override-reason` is the
+  operator equivalent, available regardless of policy. Agents cannot use it:
+  overrides remain CLI-only human actions.
+- `foremerge checks verify-symbols true` warns when a published `symbol:` scope
+  names something that appears nowhere in the worktree. Off by default, and
+  always a warning, because a scope may legitimately name something the agent is
+  about to create.
+- `foremerge doctor` reports whether the registered checks can actually run
+  here, and warns when none are registered under a strict policy.
 
 - `fmg` is a short name for the `foremerge` command. It is the same binary
   installed under a second name, so `fmg status` and `foremerge status` are
@@ -24,6 +54,35 @@ changes when they are called out here with a migration note.
   prints guidance to stderr on startup, and answers a bare tool name with the
   equivalent JSON-RPC line. Both are suppressed when stdin is a pipe, so client
   sessions are byte for byte unchanged.
+
+### Fixed
+
+- Symbol scopes are normalized to `container::member`, discarding namespace,
+  module and path prefixes, so `App\Services\Report::render` and
+  `Report::render` are one scope. Agents describe the same method differently
+  and previously never collided at all, which silently defeated overlap
+  detection for the case it exists to catch. The deliberate cost is that two
+  same-named classes in different namespaces now share a scope and can warn
+  about each other: for an advisory system a spurious warning is cheap and a
+  missed collision is the failure that matters. Other scope kinds keep their key
+  verbatim, because a path or a route is already unambiguous.
+- An agent may claim while its intent is `IN_PROGRESS`, which is how a long task
+  renews its lease. Previously there was no renew and no re-claim, so work that
+  outlasted its lease lost its claims with no way to hold them and no signal
+  that it had happened. Re-claiming a scope the intent already holds now extends
+  that claim in place instead of stacking a second row for the same scope.
+- Acceptance can record that nothing was verified. A repository with no test
+  suite could not complete the lifecycle at all, and the only way through was to
+  validate a no-op command such as `true`, which wrote a passing validation into
+  the append-only, hash-chained log for work that nothing had checked. The gate
+  exists so an agent's assertion is never mistaken for evidence, and its only
+  workaround was to fabricate evidence. ChangeSets now carry the honest outcome
+  (`VERIFIED`, `FAILED` or `UNVERIFIED`) and the reason, on the record and in
+  the acceptance event.
+- `foremerge status` no longer counts silent agents as active. Registration
+  status never expired, so a fleet that died hours earlier still reported as
+  fully working; agents unseen for over two hours are now shown as silent and
+  excluded from the active count. Claims already expired correctly.
 
 ## [0.3.1] - 2026-08-24
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,23 @@ foremerge checks set test -- cargo test --all-targets
 foremerge doctor --client all
 ```
 
+Acceptance is verification-gated: Foremerge runs the check itself rather than
+taking an agent's word for it. Pick a check that is fast and that would actually
+catch a broken handoff, such as a build or a typecheck, rather than a full CI
+suite; this gate decides whether other agents may treat the work as done, and it
+does not replace CI. If this repository has nothing meaningful to verify, say so
+once rather than registering a check that always passes:
+
+```sh
+foremerge checks policy advisory
+```
+
+Work accepted that way is recorded as `UNVERIFIED` with the reason, so the audit
+trail never implies a check ran when none did. `foremerge doctor` reports
+whether the registered checks can actually run here, which matters in agent
+worktrees, because dependency directories are usually gitignored and
+`git worktree add` will not create them.
+
 Use `setup codex`, `setup claude`, or `setup cursor` for one client. Setup
 preserves unrelated configuration (including key order in project MCP JSON) and
 refuses to replace a differing or stale skill or Foremerge MCP entry unless you

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -13,6 +13,25 @@ const MAX_COMMAND_BYTES: usize = 64 * 1024;
 const MAX_ARGS: usize = 128;
 const MAX_TIMEOUT_SECONDS: u64 = 3600;
 
+/// What acceptance requires when Foremerge has not verified the work itself.
+///
+/// This governs agents. A human operator can always override from the CLI, and
+/// either way the outcome is recorded on the ChangeSet rather than disguised as
+/// a check that passed.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum AcceptancePolicy {
+    /// Only work Foremerge verified itself may be accepted. The default,
+    /// because it is the existing behaviour and the stronger guarantee.
+    #[default]
+    Strict,
+    /// Work with nothing to verify may be accepted, and is recorded as
+    /// `UNVERIFIED` with a reason. A check that ran and *failed* still needs an
+    /// operator override, because a failure is real evidence rather than an
+    /// absence of it.
+    Advisory,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct NamedCheck {
     pub command: Vec<String>,
@@ -24,6 +43,13 @@ pub struct CheckRegistry {
     pub version: u32,
     #[serde(default)]
     pub checks: BTreeMap<String, NamedCheck>,
+    #[serde(default)]
+    pub acceptance_policy: AcceptancePolicy,
+    /// Warn when a published `symbol:` scope names something that appears
+    /// nowhere in the worktree. Off by default, because a scope may legitimately
+    /// name something the agent is about to create.
+    #[serde(default)]
+    pub verify_symbol_scopes: bool,
 }
 
 impl Default for CheckRegistry {
@@ -31,6 +57,8 @@ impl Default for CheckRegistry {
         Self {
             version: CONFIG_VERSION,
             checks: BTreeMap::new(),
+            acceptance_policy: AcceptancePolicy::default(),
+            verify_symbol_scopes: false,
         }
     }
 }
@@ -84,6 +112,107 @@ pub fn set_at(config_path: &Path, name: &str, check: NamedCheck) -> Result<Check
     registry.checks.insert(name.to_string(), check);
     save_path(config_path, &registry)?;
     Ok(registry)
+}
+
+/// Set the acceptance policy for this repository.
+pub fn set_policy_at(config_path: &Path, policy: AcceptancePolicy) -> Result<CheckRegistry> {
+    let mut registry = load_path(config_path)?;
+    registry.acceptance_policy = policy;
+    save_path(config_path, &registry)?;
+    Ok(registry)
+}
+
+/// The acceptance policy recorded for a repository, defaulting to strict when
+/// no registry file exists yet. Read failures also fall back to strict: a
+/// damaged registry must never be a route to accepting unverified work.
+pub fn acceptance_policy_at(config_path: &Path) -> AcceptancePolicy {
+    load_path(config_path)
+        .map(|registry| registry.acceptance_policy)
+        .unwrap_or_default()
+}
+
+/// Turn the symbol-existence advisory on or off for this repository.
+pub fn set_verify_symbol_scopes_at(config_path: &Path, enabled: bool) -> Result<CheckRegistry> {
+    let mut registry = load_path(config_path)?;
+    registry.verify_symbol_scopes = enabled;
+    save_path(config_path, &registry)?;
+    Ok(registry)
+}
+
+/// Whether the symbol-existence advisory is enabled, defaulting to off.
+pub fn verify_symbol_scopes_at(config_path: &Path) -> bool {
+    load_path(config_path)
+        .map(|registry| registry.verify_symbol_scopes)
+        .unwrap_or(false)
+}
+
+/// Whether the registered checks can actually run from `cwd`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CheckDiagnostic {
+    pub registered: usize,
+    pub acceptance_policy: AcceptancePolicy,
+    /// Checks whose executable could not be found, or whose relative path
+    /// argument does not exist here.
+    pub unrunnable: Vec<String>,
+    pub warnings: Vec<String>,
+}
+
+/// Diagnose the registry without running anything.
+///
+/// A check is reported as unrunnable when its executable is not on `PATH` and
+/// not a file here, or when a relative path in its argv does not exist in this
+/// worktree. That second case is the one that bites: dependency directories are
+/// usually gitignored, so `git worktree add` never creates them and every check
+/// fails in every agent worktree while the primary checkout looks fine.
+pub fn diagnose(config_path: &Path, cwd: &Path) -> CheckDiagnostic {
+    let registry = load_path(config_path).unwrap_or_default();
+    let mut unrunnable = Vec::new();
+    let mut warnings = Vec::new();
+    for (name, check) in &registry.checks {
+        let Some(program) = check.command.first() else {
+            continue;
+        };
+        if !executable_exists(program, cwd) {
+            unrunnable.push(name.clone());
+            warnings.push(format!(
+                "check '{name}' cannot run here: '{program}' is not on PATH and not a file in this worktree"
+            ));
+            continue;
+        }
+        // A relative path argument that does not exist is the gitignored
+        // dependency directory problem.
+        if let Some(missing) = check.command[1..]
+            .iter()
+            .filter(|argument| argument.contains('/') && !argument.starts_with('-'))
+            .find(|argument| !cwd.join(argument).exists())
+        {
+            unrunnable.push(name.clone());
+            warnings.push(format!(
+                "check '{name}' refers to '{missing}', which does not exist in this worktree; if it is gitignored, `git worktree add` will not have created it"
+            ));
+        }
+    }
+    if registry.checks.is_empty() && registry.acceptance_policy == AcceptancePolicy::Strict {
+        warnings.push(
+            "no verification checks are registered and the acceptance policy is strict, so no ChangeSet can be accepted here. Register one with `foremerge checks set <name> -- <command>`, or, if this repository has nothing to verify, run `foremerge checks policy advisory`.".to_string(),
+        );
+    }
+    CheckDiagnostic {
+        registered: registry.checks.len(),
+        acceptance_policy: registry.acceptance_policy,
+        unrunnable,
+        warnings,
+    }
+}
+
+fn executable_exists(program: &str, cwd: &Path) -> bool {
+    let candidate = Path::new(program);
+    if candidate.components().count() > 1 {
+        return cwd.join(candidate).exists() || candidate.exists();
+    }
+    std::env::var_os("PATH")
+        .map(|paths| std::env::split_paths(&paths).any(|dir| dir.join(program).is_file()))
+        .unwrap_or(false)
 }
 
 pub fn remove(cwd: &Path, name: &str) -> Result<CheckRegistry> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -155,6 +155,38 @@ enum CheckCommand {
     List,
     /// Remove a trusted verification check.
     Remove { name: String },
+    /// Warn when a published symbol scope names something that exists nowhere
+    /// in the worktree. Off by default.
+    VerifySymbols {
+        #[arg(action = clap::ArgAction::Set)]
+        enabled: bool,
+    },
+    /// Show or set what acceptance requires when Foremerge verified nothing.
+    Policy {
+        /// Omit to show the current policy.
+        #[arg(value_enum)]
+        policy: Option<AcceptancePolicyArg>,
+    },
+}
+
+/// CLI spelling of `checks::AcceptancePolicy`.
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum AcceptancePolicyArg {
+    /// Only work Foremerge verified itself may be accepted.
+    Strict,
+    /// Work with nothing to verify may be accepted, recorded as UNVERIFIED
+    /// with a reason. A check that ran and failed still needs an operator
+    /// override.
+    Advisory,
+}
+
+impl From<AcceptancePolicyArg> for checks::AcceptancePolicy {
+    fn from(value: AcceptancePolicyArg) -> Self {
+        match value {
+            AcceptancePolicyArg::Strict => Self::Strict,
+            AcceptancePolicyArg::Advisory => Self::Advisory,
+        }
+    }
 }
 
 #[derive(Debug, Subcommand)]
@@ -244,6 +276,16 @@ enum WorkCommand {
         intent_id: String,
         #[arg(long = "agent")]
         agent_id: String,
+    },
+    /// Take over an intent whose agent has stopped. Refused while any of its
+    /// claims are still live, so it cannot take work from a busy agent.
+    Adopt {
+        intent_id: String,
+        #[arg(long = "agent")]
+        agent_id: String,
+        /// Recorded on the handover.
+        #[arg(long)]
+        reason: String,
     },
     /// Poll semantic events as they cross useful boundaries.
     Watch {
@@ -368,8 +410,14 @@ enum ChangeSetCommand {
         git_ref: Option<String>,
         #[arg(long)]
         allow_high_conflicts: bool,
-        /// Required rationale when explicitly overriding unresolved HIGH conflicts.
-        #[arg(long, requires = "allow_high_conflicts")]
+        /// Accept work Foremerge did not verify, or verified as failing. The
+        /// ChangeSet records it as UNVERIFIED or FAILED with your reason, so
+        /// the audit trail never implies a check ran when none did.
+        #[arg(long)]
+        allow_unverified: bool,
+        /// Required rationale when overriding unresolved HIGH conflicts or
+        /// accepting unverified work.
+        #[arg(long)]
         override_reason: Option<String>,
     },
     /// Record the durable Git commit after integration.
@@ -643,6 +691,13 @@ async fn execute(cli: Cli) -> Result<Completion> {
             let next_client_step = client_diagnostics
                 .as_ref()
                 .and_then(|values| values.iter().find_map(|value| value.next_step.clone()));
+            // Acceptance is verification-gated, so a repository whose checks
+            // cannot run is one where no work can ever be accepted. That was
+            // only discoverable by an agent failing at the last step, which is
+            // the worst possible moment to find out.
+            let checks_diagnosis = repo
+                .as_ref()
+                .map(|value| checks::diagnose(&checks::registry_path(&value.common_dir), &cwd));
             let report = DoctorReport {
                 version: env!("CARGO_PKG_VERSION").to_string(),
                 database: database.to_string_lossy().into_owned(),
@@ -676,8 +731,14 @@ async fn execute(cli: Cli) -> Result<Completion> {
                         .to_string()
                 },
                 clients: client_diagnostics,
+                checks: checks_diagnosis.clone(),
             };
             emit(cli.json, serde_json::to_value(report)?)?;
+            if let Some(diagnosis) = checks_diagnosis {
+                for warning in &diagnosis.warnings {
+                    eprintln!("warning: {warning}");
+                }
+            }
         }
         Commands::Daemon { bind, no_auth } => {
             if !bind.ip().is_loopback() {
@@ -726,6 +787,13 @@ async fn execute(cli: Cli) -> Result<Completion> {
                 )?,
                 CheckCommand::List => checks::load_at(&registry_path)?,
                 CheckCommand::Remove { name } => checks::remove_at(&registry_path, &name)?,
+                CheckCommand::VerifySymbols { enabled } => {
+                    checks::set_verify_symbol_scopes_at(&registry_path, enabled)?
+                }
+                CheckCommand::Policy { policy: None } => checks::load_at(&registry_path)?,
+                CheckCommand::Policy {
+                    policy: Some(policy),
+                } => checks::set_policy_at(&registry_path, policy.into())?,
             };
             emit(
                 cli.json,
@@ -865,6 +933,11 @@ async fn execute_service(
             intent_id,
             agent_id,
         }) => serde_json::to_value(service.start_work(&agent_id, &intent_id)?)?,
+        Commands::Work(WorkCommand::Adopt {
+            intent_id,
+            agent_id,
+            reason,
+        }) => serde_json::to_value(service.adopt_intent(&agent_id, &intent_id, &reason)?)?,
         Commands::Work(WorkCommand::Discard {
             intent_id,
             agent_id,
@@ -999,12 +1072,14 @@ async fn execute_service(
             changeset_id,
             git_ref,
             allow_high_conflicts,
+            allow_unverified,
             override_reason,
         }) => serde_json::to_value(service.accept_changeset(
             &changeset_id,
             AcceptRequest {
                 git_ref,
                 allow_high_conflicts,
+                allow_unverified,
                 override_reason,
             },
         )?)?,
@@ -1075,7 +1150,18 @@ fn pad(value: &str, width: usize) -> String {
 fn render_status(report: &StatusReport) -> String {
     let mut out = String::new();
 
-    out.push_str(&format!("Agents ({} active)\n", report.agents.len()));
+    // Counting silent agents as active is how `status` came to claim eleven
+    // agents were working when most had been dead for hours.
+    let live = report.agents.iter().filter(|agent| !agent.stale).count();
+    let stale = report.agents.len() - live;
+    out.push_str(&format!(
+        "Agents ({live} active{})\n",
+        if stale > 0 {
+            format!(", {stale} silent for over 2h")
+        } else {
+            String::new()
+        }
+    ));
     if report.agents.is_empty() {
         out.push_str("  none\n");
     } else {

--- a/src/db.rs
+++ b/src/db.rs
@@ -11,7 +11,7 @@ use std::sync::{Arc, Mutex, MutexGuard, TryLockError};
 use std::time::Duration;
 use uuid::Uuid;
 
-const DATABASE_SCHEMA_VERSION: i64 = 4;
+const DATABASE_SCHEMA_VERSION: i64 = 5;
 // Event hashing is versioned independently from the mutable SQLite projection
 // schema. A database migration must not silently change the hash material for
 // otherwise identical events.
@@ -271,6 +271,8 @@ impl Store {
                 integration_commit TEXT,
                 supersedes_changeset_id TEXT REFERENCES changesets(id),
                 worktree TEXT,
+                acceptance_verification TEXT,
+                acceptance_reason TEXT,
                 fingerprint TEXT NOT NULL,
                 status TEXT NOT NULL,
                 created_at TEXT NOT NULL,
@@ -529,7 +531,12 @@ impl Store {
                 [],
             )?;
         }
-        for column in ["accepted_commit", "integration_commit"] {
+        for column in [
+            "accepted_commit",
+            "integration_commit",
+            "acceptance_verification",
+            "acceptance_reason",
+        ] {
             let exists: bool = conn.query_row(
                 "SELECT EXISTS(
                    SELECT 1 FROM pragma_table_info('changesets') WHERE name = ?1
@@ -577,7 +584,53 @@ impl Store {
         // an interrupted migration, so every intent is reprojected once.
         // Afterwards only intents with no projection at all need work, which is
         // the ordinary case of a store written by an older binary.
-        let mut statement = if stored_version < 3 {
+        // Schema 5 normalizes symbol scopes, discarding namespace and path
+        // prefixes so `App\\Services\\Report::render` and `Report::render` are
+        // one scope. Every canonical form stored under an older schema was
+        // computed by the old rule, so a store that kept them would have new
+        // rows that could never match old ones: exactly the silent
+        // non-detection this release fixes. The projection is therefore rebuilt
+        // from `intents.scopes_json`, which is the source of truth and is
+        // untouched by the change.
+        if stored_version < 5 {
+            conn.execute("DELETE FROM intent_scopes", [])?;
+            let mut statement = conn.prepare("SELECT id, scope_kind, scope_key FROM claims")?;
+            let claims = statement
+                .query_map([], |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                    ))
+                })?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+            drop(statement);
+            for (claim_id, kind, key) in claims {
+                let canonical = Scope::new(&kind, &key).canonical();
+                conn.execute(
+                    "UPDATE claims SET canonical_scope = ?2 WHERE id = ?1",
+                    params![claim_id, canonical],
+                )?;
+            }
+            // Two live claims on one intent can now share a canonical scope
+            // where they did not before. Keep the longest-lived and release the
+            // rest, so the intent does not appear to hold the same scope twice.
+            conn.execute(
+                "UPDATE claims SET status = 'RELEASED'
+                 WHERE status = 'ACTIVE' AND id NOT IN (
+                   SELECT id FROM claims c WHERE c.status = 'ACTIVE'
+                   AND c.lease_expires_at = (
+                     SELECT MAX(lease_expires_at) FROM claims d
+                     WHERE d.intent_id = c.intent_id
+                     AND d.canonical_scope = c.canonical_scope
+                     AND d.status = 'ACTIVE'
+                   )
+                   GROUP BY c.intent_id, c.canonical_scope
+                 )",
+                [],
+            )?;
+        }
+        let mut statement = if stored_version < 5 {
             conn.prepare("SELECT id, scopes_json FROM intents")?
         } else {
             conn.prepare(

--- a/src/git.rs
+++ b/src/git.rs
@@ -590,6 +590,26 @@ fn git_output_bytes_limited(cwd: &Path, args: &[&str]) -> Result<LimitedOutput> 
     }
 }
 
+/// Whether `needle` appears anywhere in the repository's tracked files.
+///
+/// Used only for the opt-in symbol-existence advisory. `git grep` is used
+/// because it already respects tracked files and ignore rules, and because Git
+/// is a dependency this project already has. A failure to run is reported as
+/// "found", so a broken search can never manufacture a warning.
+pub fn tracked_content_contains(worktree: &Path, needle: &str) -> bool {
+    if needle.trim().is_empty() {
+        return true;
+    }
+    Command::new("git")
+        .arg("-C")
+        .arg(worktree)
+        .args(["grep", "--ignore-case", "--fixed-strings", "--quiet", "-e"])
+        .arg(needle)
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(true)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -382,6 +382,11 @@ async fn call_tool(service: &Foremerge, params: Value) -> Result<Value, (i64, St
                             AcceptRequest {
                                 git_ref: request.git_ref,
                                 allow_high_conflicts: false,
+                                // Agents never override. Accepting work with
+                                // nothing to verify is governed by the
+                                // repository's acceptance policy, which a human
+                                // sets once, not by the agent asking nicely.
+                                allow_unverified: false,
                                 override_reason: None,
                             },
                         )

--- a/src/model.rs
+++ b/src/model.rs
@@ -52,9 +52,58 @@ impl Scope {
         Self::parse(&format!("{}:{}", self.kind, self.key))
     }
 
+    /// The identity two agents must agree on for an overlap to be detected.
+    ///
+    /// Symbol keys are reduced to their last two `::` segments with any
+    /// namespace, module or path prefix removed, so
+    /// `App\Services\Report::render` and `Report::render` are one scope rather
+    /// than two. Agents describe the same method differently, and before this
+    /// they simply never collided.
+    ///
+    /// The deliberate cost is that two same-named classes in different
+    /// namespaces now share a scope and can warn about each other. For an
+    /// advisory system that is the right direction to err: a spurious warning
+    /// is cheap, and a missed collision is the failure the tool exists to
+    /// prevent. Other scope kinds keep their key verbatim, because a path or a
+    /// route is already unambiguous and truncating it would lose meaning.
     pub fn canonical(&self) -> String {
-        format!("{}:{}", self.kind.to_lowercase(), self.key.to_lowercase())
+        let key = if self.kind.eq_ignore_ascii_case("symbol") {
+            normalize_symbol_key(&self.key)
+        } else {
+            self.key.to_lowercase()
+        };
+        format!("{}:{}", self.kind.to_lowercase(), key)
     }
+}
+
+/// Reduce a symbol key to `container::member`, or `member` when it has no
+/// container, discarding namespace and path prefixes in either part.
+fn normalize_symbol_key(key: &str) -> String {
+    let segments: Vec<&str> = key
+        .split("::")
+        .map(str::trim)
+        .filter(|segment| !segment.is_empty())
+        .collect();
+    if segments.is_empty() {
+        return key.trim().to_lowercase();
+    }
+    let start = segments.len().saturating_sub(2);
+    segments[start..]
+        .iter()
+        .map(|segment| {
+            // Whatever separator the language uses, only the final name
+            // identifies the thing: `App\Services\Report`, `app/services/Report`
+            // and `app.services.Report` all name `Report`.
+            segment
+                .rsplit(['\\', '/', '.'])
+                .next()
+                .unwrap_or(segment)
+                .trim()
+                .to_lowercase()
+        })
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<_>>()
+        .join("::")
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -129,6 +178,10 @@ pub struct IntentDetail {
 pub struct PublishIntentOutcome {
     pub intent: Intent,
     pub conflicts: Vec<Conflict>,
+    /// Advisory notes about the intent itself, as opposed to conflicts with
+    /// other agents. Empty unless a repository opts in to extra checking.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -317,6 +370,14 @@ pub struct ChangeSet {
     pub supersedes_changeset_id: Option<String>,
     pub fingerprint: String,
     pub status: String,
+    /// What Foremerge actually knew about this work when it was accepted:
+    /// `VERIFIED`, `FAILED` or `UNVERIFIED`. `None` until acceptance.
+    #[serde(default)]
+    pub acceptance_verification: Option<String>,
+    /// Why unverified or failing work was accepted anyway. Recorded so the
+    /// audit trail never has to imply a check ran when none did.
+    #[serde(default)]
+    pub acceptance_reason: Option<String>,
     pub created_at: String,
     pub updated_at: String,
     /// Open or coordinating conflicts touching this ChangeSet's intent at the
@@ -398,6 +459,11 @@ pub struct AcceptRequest {
     pub git_ref: Option<String>,
     #[serde(default)]
     pub allow_high_conflicts: bool,
+    /// Accept work that Foremerge did not verify, or verified as failing.
+    /// Requires `override_reason`, and the outcome is recorded on the
+    /// ChangeSet rather than being disguised as a passing check.
+    #[serde(default)]
+    pub allow_unverified: bool,
     #[serde(default)]
     pub override_reason: Option<String>,
 }
@@ -472,6 +538,10 @@ pub struct DoctorReport {
     /// was asked to inspect specific clients.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub clients: Option<Vec<crate::integrations::ClientDiagnostic>>,
+    /// Whether the repository's registered verification checks can actually
+    /// run here. Absent when the store is not bound to a Git repository.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub checks: Option<crate::checks::CheckDiagnostic>,
 }
 
 /// One consistent snapshot answering "what are my agents doing right now".
@@ -499,7 +569,23 @@ pub struct StatusAgent {
     pub name: String,
     pub model: Option<String>,
     pub worktree: Option<String>,
+    /// When this agent last called Foremerge.
+    #[serde(default)]
+    pub last_seen_at: String,
+    /// Whether it has been silent for longer than [`AGENT_STALE_AFTER_SECONDS`].
+    /// Registration status alone never expires, so without this a fleet that
+    /// died hours ago still reports as fully active.
+    #[serde(default)]
+    pub stale: bool,
 }
+
+/// How long an agent may be silent before `status` stops calling it active.
+///
+/// Agents go quiet for legitimate reasons: one drafting a long document can
+/// easily run forty minutes between tool calls. Two hours is well beyond that
+/// while still being far short of "yesterday". This marks agents rather than
+/// hiding them, so nothing is ever silently dropped from view.
+pub const AGENT_STALE_AFTER_SECONDS: i64 = 2 * 60 * 60;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StatusIntentGroup {
@@ -556,4 +642,80 @@ pub struct StatusChangeSetGroup {
 
 pub fn empty_object() -> Value {
     json!({})
+}
+
+#[cfg(test)]
+mod scope_tests {
+    use super::*;
+
+    #[test]
+    fn a_namespaced_symbol_and_a_bare_one_are_the_same_scope() {
+        // The GPTree dogfood run: two agents named one method two ways and so
+        // never collided.
+        let namespaced = Scope::new(
+            "symbol",
+            "App\\Services\\ConversationContextService::buildContext",
+        );
+        let bare = Scope::new("symbol", "ConversationContextService::buildContext");
+        assert_eq!(namespaced.canonical(), bare.canonical());
+        assert_eq!(
+            bare.canonical(),
+            "symbol:conversationcontextservice::buildcontext"
+        );
+    }
+
+    #[test]
+    fn every_language_separator_is_reduced_to_the_final_name() {
+        for key in [
+            "App\\Services\\Report::render",
+            "app/services/Report::render",
+            "app.services.Report::render",
+            "crate::app::services::Report::render",
+            "Report::render",
+        ] {
+            assert_eq!(
+                Scope::new("symbol", key).canonical(),
+                "symbol:report::render",
+                "{key} did not normalize"
+            );
+        }
+    }
+
+    #[test]
+    fn a_symbol_without_a_container_keeps_its_own_name() {
+        assert_eq!(
+            Scope::new("symbol", "App\\Services\\Report").canonical(),
+            "symbol:report"
+        );
+        assert_eq!(Scope::new("symbol", "render").canonical(), "symbol:render");
+    }
+
+    #[test]
+    fn non_symbol_scopes_keep_their_key_verbatim() {
+        // A path or a route is already unambiguous, and truncating it would
+        // merge genuinely different files.
+        assert_eq!(
+            Scope::new("file", "app/Services/Report.php").canonical(),
+            "file:app/services/report.php"
+        );
+        assert_eq!(
+            Scope::new("api", "/api/admin/reports/{id}").canonical(),
+            "api:/api/admin/reports/{id}"
+        );
+        assert_ne!(
+            Scope::new("file", "a/Report.php").canonical(),
+            Scope::new("file", "b/Report.php").canonical()
+        );
+    }
+
+    #[test]
+    fn normalization_is_idempotent() {
+        // Canonical forms are stored, so a second pass must not shift them
+        // again or a later migration would keep chasing its own output.
+        for key in ["App\\Services\\Report::render", "Report::render", "render"] {
+            let once = Scope::new("symbol", key).canonical();
+            let stripped = once.strip_prefix("symbol:").unwrap();
+            assert_eq!(Scope::new("symbol", stripped).canonical(), once);
+        }
+    }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -600,6 +600,11 @@ pub struct StatusIntent {
     pub agent_id: String,
     pub agent_name: String,
     pub summary: String,
+    /// Set when this intent is in a working state but nothing is holding it:
+    /// every claim has lapsed and its agent has gone silent. The work is not
+    /// progressing and can be taken over with `foremerge work adopt`.
+    #[serde(default)]
+    pub stranded: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/service.rs
+++ b/src/service.rs
@@ -2464,6 +2464,19 @@ impl Foremerge {
                 });
             }
         }
+        let stale_agents: std::collections::HashSet<String> = agents
+            .iter()
+            .filter(|agent| agent.stale)
+            .map(|agent| agent.id.clone())
+            .collect();
+        let mut statement = tx.prepare(
+            "SELECT DISTINCT intent_id FROM claims
+             WHERE status = 'ACTIVE' AND lease_expires_at > ?1",
+        )?;
+        let intents_with_live_claims: std::collections::HashSet<String> = statement
+            .query_map([Utc::now().to_rfc3339()], |row| row.get::<_, String>(0))?
+            .collect::<rusqlite::Result<std::collections::HashSet<_>>>()?;
+        drop(statement);
         let agent_name = |agent_id: &str| {
             agent_names
                 .get(agent_id)
@@ -2499,6 +2512,14 @@ impl Foremerge {
                     agent_id: intent.agent_id.clone(),
                     agent_name: agent_name(&intent.agent_id),
                     summary: intent.summary.clone(),
+                    // An intent that says IN_PROGRESS while nothing holds it
+                    // and nobody is home is not in progress. Reporting it as
+                    // though it were is how a finished run still looked busy.
+                    stranded: matches!(
+                        intent.status.as_str(),
+                        "CLAIMED" | "IN_PROGRESS" | "PROVISIONAL"
+                    ) && stale_agents.contains(&intent.agent_id)
+                        && !intents_with_live_claims.contains(&intent.id),
                 })
                 .collect();
             if !members.is_empty() {

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,9 +1,10 @@
+use crate::checks;
 use crate::conflict::{self, IntentCandidate};
 use crate::db::Store;
 use crate::git;
 use crate::model::*;
 use anyhow::{Context, Result, bail};
-use chrono::{Duration as ChronoDuration, Utc};
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use rusqlite::{Connection, OptionalExtension, Transaction, params};
 use serde::de::DeserializeOwned;
 use serde_json::{Value, json};
@@ -44,6 +45,99 @@ const NONTERMINAL_CHANGESET_STATES: &[&str] = &["PROVISIONAL", "VALIDATED", "ACC
 #[derive(Clone)]
 pub struct Foremerge {
     store: Store,
+}
+
+/// The three honest answers to "what did Foremerge verify about this work".
+pub const VERIFICATION_VERIFIED: &str = "VERIFIED";
+pub const VERIFICATION_FAILED: &str = "FAILED";
+pub const VERIFICATION_UNVERIFIED: &str = "UNVERIFIED";
+
+/// The repository's acceptance policy, read through a connection the caller
+/// already holds. `Foremerge::repository_common_dir` takes the store lock, so
+/// calling it from inside a locked block would deadlock.
+fn acceptance_policy(conn: &Connection) -> Result<checks::AcceptancePolicy> {
+    let common_dir: Option<String> = conn
+        .query_row(
+            "SELECT value FROM meta WHERE key = 'repository_common_dir'",
+            [],
+            |row| row.get(0),
+        )
+        .optional()?;
+    Ok(common_dir
+        .map(|dir| checks::acceptance_policy_at(&checks::registry_path(&PathBuf::from(dir))))
+        .unwrap_or_default())
+}
+
+/// Whether this repository opted in to the symbol-existence advisory.
+fn verify_symbol_scopes(conn: &Connection) -> Result<bool> {
+    let common_dir: Option<String> = conn
+        .query_row(
+            "SELECT value FROM meta WHERE key = 'repository_common_dir'",
+            [],
+            |row| row.get(0),
+        )
+        .optional()?;
+    Ok(common_dir
+        .map(|dir| checks::verify_symbol_scopes_at(&checks::registry_path(&PathBuf::from(dir))))
+        .unwrap_or(false))
+}
+
+/// Advisory notes for `symbol:` scopes whose name appears nowhere in the
+/// worktree. A warning, never a rejection: a scope may legitimately name
+/// something the agent is about to create.
+fn missing_symbol_warnings(worktree: &Option<String>, scopes: &[Scope]) -> Vec<String> {
+    let Some(worktree) = worktree.as_deref().map(PathBuf::from) else {
+        return Vec::new();
+    };
+    scopes
+        .iter()
+        .filter(|scope| scope.kind.eq_ignore_ascii_case("symbol"))
+        .filter_map(|scope| {
+            // The member is the part that has to exist; a container name alone
+            // is too generic to be evidence either way.
+            let member = scope.key.rsplit("::").next().unwrap_or(&scope.key).trim();
+            if member.is_empty() || git::tracked_content_contains(&worktree, member) {
+                return None;
+            }
+            Some(format!(
+                "scope `symbol:{}` names `{member}`, which appears nowhere in this worktree; if it is not something you are about to create, the symbol you actually edit is still unclaimed",
+                scope.key
+            ))
+        })
+        .collect()
+}
+
+/// What Foremerge actually knows about a ChangeSet, from the newest validation
+/// on record. A check that passed against a different fingerprint says nothing
+/// about this tree, so it counts as unverified rather than as evidence.
+fn verification_state(
+    conn: &Connection,
+    changeset_id: &str,
+    fingerprint: &str,
+) -> Result<(&'static str, Option<&'static str>)> {
+    let valid: Option<(bool, String)> = conn
+        .query_row(
+            "SELECT passed, fingerprint FROM validations WHERE changeset_id = ?1
+             ORDER BY run_at DESC LIMIT 1",
+            [changeset_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .optional()?;
+    Ok(match valid {
+        Some((true, recorded)) if recorded == fingerprint => (VERIFICATION_VERIFIED, None),
+        Some((false, recorded)) if recorded == fingerprint => (
+            VERIFICATION_FAILED,
+            Some("the registered check ran against this fingerprint and did not pass"),
+        ),
+        Some(_) => (
+            VERIFICATION_UNVERIFIED,
+            Some("the only validation on record was run against a different fingerprint"),
+        ),
+        None => (
+            VERIFICATION_UNVERIFIED,
+            Some("no verification check was run against this ChangeSet"),
+        ),
+    })
 }
 
 impl Foremerge {
@@ -302,8 +396,88 @@ impl Foremerge {
                 conflicts.push(persist_conflict(&tx, &detected, Some(&agent.id))?);
             }
         }
+        // Opt-in advisory: a scope naming a symbol that exists nowhere protects
+        // nothing, because the real symbol stays unclaimed while the agent
+        // believes it holds a reservation. Computed before commit so the read
+        // uses the same connection, but it never blocks the publish.
+        let warnings = if verify_symbol_scopes(&tx)? {
+            missing_symbol_warnings(&agent.worktree, &intent.scopes)
+        } else {
+            Vec::new()
+        };
         tx.commit()?;
-        Ok(PublishIntentOutcome { intent, conflicts })
+        Ok(PublishIntentOutcome {
+            intent,
+            conflicts,
+            warnings,
+        })
+    }
+
+    /// Transfer a stranded intent to another agent.
+    ///
+    /// An agent that dies mid-task leaves its intent owned by an agent that
+    /// will never return, and ownership is otherwise permanent, so the work
+    /// could only be duplicated. Adoption is deliberately narrow: it is refused
+    /// while any claim on the intent is still live, so it can never be used to
+    /// take work away from an agent that is simply busy. The expiry of every
+    /// claim is the evidence that the previous owner has stopped.
+    pub fn adopt_intent(&self, agent_id: &str, intent_id: &str, reason: &str) -> Result<Intent> {
+        let reason = reason.trim();
+        if reason.is_empty() {
+            bail!("INVALID_INPUT: adopting an intent requires a reason, which is recorded");
+        }
+        let mut conn = self.store.lock()?;
+        let tx = Store::immediate_tx(&mut conn)?;
+        let agent = agent_by_id(&tx, agent_id)?;
+        let intent = intent_by_id(&tx, intent_id)?;
+        if intent.agent_id == agent.id {
+            bail!("INVALID_INPUT: intent {intent_id} already belongs to this agent");
+        }
+        require_state(
+            &intent.status,
+            &["INTENT", "CLAIMED", "IN_PROGRESS", "PROVISIONAL"],
+            "adopt",
+        )?;
+        let now = Utc::now().to_rfc3339();
+        let live: i64 = tx.query_row(
+            "SELECT COUNT(*) FROM claims
+             WHERE intent_id = ?1 AND status = 'ACTIVE' AND lease_expires_at > ?2",
+            params![intent_id, now],
+            |row| row.get(0),
+        )?;
+        if live > 0 {
+            bail!(
+                "FORBIDDEN: intent {intent_id} still holds {live} live claim(s); its owner has not stopped. Wait for the leases to expire, or ask that agent to discard the work."
+            );
+        }
+        let previous_owner = intent.agent_id.clone();
+        tx.execute(
+            "UPDATE intents SET agent_id = ?2 WHERE id = ?1 AND agent_id = ?3",
+            params![intent_id, agent.id, previous_owner],
+        )?;
+        // Expired claims belong to the agent that is gone. Release them
+        // explicitly so the audit trail shows the handover rather than leaving
+        // rows that read as another agent's holdings.
+        tx.execute(
+            "UPDATE claims SET status = 'RELEASED', released_at = ?2
+             WHERE intent_id = ?1 AND status = 'ACTIVE'",
+            params![intent_id, now],
+        )?;
+        Store::append_event(
+            &tx,
+            "intent.adopted",
+            "Intent",
+            intent_id,
+            Some(&agent.id),
+            &json!({
+                "previous_agent_id": previous_owner,
+                "adopted_by_agent_id": agent.id,
+                "reason": reason
+            }),
+        )?;
+        let adopted = intent_by_id(&tx, intent_id)?;
+        tx.commit()?;
+        Ok(adopted)
     }
 
     pub fn claim_work(&self, mut request: ClaimWorkRequest) -> Result<ClaimOutcome> {
@@ -316,9 +490,19 @@ impl Foremerge {
         let agent = agent_by_id(&tx, &request.agent_id)?;
         let intent = intent_by_id(&tx, &request.intent_id)?;
         if intent.agent_id != agent.id {
-            bail!("FORBIDDEN: an agent may only claim work for its own intent");
+            bail!(
+                "FORBIDDEN: an agent may only claim work for its own intent. If {owner} has stopped, adopt the intent first with `foremerge work adopt`, which is refused while any of its claims are still live.",
+                owner = intent.agent_id
+            );
         }
-        require_state(&intent.status, &["INTENT", "CLAIMED"], "claim work")?;
+        // IN_PROGRESS is claimable by the owner so that an agent whose work
+        // outlasts its lease can renew it. Without this a long task silently
+        // loses the very protection it asked for, with no way to hold it.
+        require_state(
+            &intent.status,
+            &["INTENT", "CLAIMED", "IN_PROGRESS"],
+            "claim work",
+        )?;
         let now = Utc::now();
         let expires = now + ChronoDuration::seconds(request.lease_seconds.clamp(60, 86_400) as i64);
         let mut claims = Vec::new();
@@ -339,33 +523,58 @@ impl Foremerge {
                 let warning = conflict::claim_overlap_conflict(&intent.id, &other_intent, &scope);
                 warnings.push(persist_conflict(&tx, &warning, Some(&agent.id))?);
             }
+            // Claiming a scope this intent already holds renews the lease in
+            // place. Stacking a second row would leave the same scope claimed
+            // twice, overstating what is held and making `status` misleading.
+            let existing_claim: Option<(String, String)> = tx
+                .query_row(
+                    "SELECT id, created_at FROM claims
+                     WHERE intent_id = ?1 AND canonical_scope = ?2 AND status = 'ACTIVE'
+                     ORDER BY created_at DESC LIMIT 1",
+                    params![intent.id, scope.canonical()],
+                    |row| Ok((row.get(0)?, row.get(1)?)),
+                )
+                .optional()?;
+            let renewed = existing_claim.is_some();
             let claim = Claim {
-                id: id("clm"),
+                id: existing_claim
+                    .as_ref()
+                    .map(|(claim_id, _)| claim_id.clone())
+                    .unwrap_or_else(|| id("clm")),
                 agent_id: agent.id.clone(),
                 intent_id: intent.id.clone(),
                 scope: scope.clone(),
                 status: "ACTIVE".to_string(),
                 reason: request.reason.clone(),
                 lease_expires_at: expires.to_rfc3339(),
-                created_at: now.to_rfc3339(),
+                created_at: existing_claim
+                    .map(|(_, created_at)| created_at)
+                    .unwrap_or_else(|| now.to_rfc3339()),
             };
-            tx.execute(
-                "INSERT INTO claims(id, agent_id, intent_id, scope_kind, scope_key,
-                 canonical_scope, status, reason, lease_expires_at, created_at)
-                 VALUES(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
-                params![
-                    claim.id,
-                    claim.agent_id,
-                    claim.intent_id,
-                    claim.scope.kind,
-                    claim.scope.key,
-                    claim.scope.canonical(),
-                    claim.status,
-                    claim.reason,
-                    claim.lease_expires_at,
-                    claim.created_at,
-                ],
-            )?;
+            if renewed {
+                tx.execute(
+                    "UPDATE claims SET lease_expires_at = ?2, reason = ?3 WHERE id = ?1",
+                    params![claim.id, claim.lease_expires_at, claim.reason],
+                )?;
+            } else {
+                tx.execute(
+                    "INSERT INTO claims(id, agent_id, intent_id, scope_kind, scope_key,
+                     canonical_scope, status, reason, lease_expires_at, created_at)
+                     VALUES(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+                    params![
+                        claim.id,
+                        claim.agent_id,
+                        claim.intent_id,
+                        claim.scope.kind,
+                        claim.scope.key,
+                        claim.scope.canonical(),
+                        claim.status,
+                        claim.reason,
+                        claim.lease_expires_at,
+                        claim.created_at,
+                    ],
+                )?;
+            }
             let intent_node =
                 Store::upsert_node(&tx, "Intent", &intent.id, &intent.summary, &json!({}))?;
             let claim_node = Store::upsert_node(
@@ -798,6 +1007,8 @@ impl Foremerge {
             supersedes_changeset_id: None,
             fingerprint: snapshot.fingerprint,
             status: "PROVISIONAL".to_string(),
+            acceptance_verification: None,
+            acceptance_reason: None,
             created_at: now.clone(),
             updated_at: now.clone(),
             open_conflicts: None,
@@ -1420,10 +1631,17 @@ impl Foremerge {
         let changeset;
         let worktree;
         let dependency_refs;
+        let verification: &str;
+        let verification_reason: Option<&str>;
+        let mut accepted_reason: Option<String> = None;
         {
             let conn = self.store.lock()?;
             changeset = changeset_by_id(&conn, changeset_id)?;
-            require_state(&changeset.status, &["VALIDATED"], "accept")?;
+            // PROVISIONAL is accepted here as a *state*; whether it may
+            // actually be accepted is decided by the verification rules below,
+            // so that "nothing was verified" is a recordable outcome instead of
+            // an unreachable one.
+            require_state(&changeset.status, &["VALIDATED", "PROVISIONAL"], "accept")?;
             worktree = conn
                 .query_row(
                     "SELECT worktree FROM changesets WHERE id = ?1",
@@ -1432,21 +1650,40 @@ impl Foremerge {
                 )?
                 .map(PathBuf::from)
                 .ok_or_else(|| anyhow::anyhow!("INVALID_INPUT: ChangeSet has no worktree"))?;
-            let valid: Option<(bool, String)> = conn
-                .query_row(
-                    "SELECT passed, fingerprint FROM validations WHERE changeset_id = ?1
-                     ORDER BY run_at DESC LIMIT 1",
-                    [changeset_id],
-                    |row| Ok((row.get(0)?, row.get(1)?)),
-                )
-                .optional()?;
-            match valid {
-                Some((true, fingerprint)) if fingerprint == changeset.fingerprint => {}
-                _ => {
-                    bail!(
-                        "CHECK_FAILED: no passing Foremerge validation for the current fingerprint"
-                    )
-                }
+            (verification, verification_reason) =
+                verification_state(&conn, changeset_id, &changeset.fingerprint)?;
+            if verification != VERIFICATION_VERIFIED {
+                let operator_reason = request
+                    .override_reason
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|reason| !reason.is_empty());
+                let policy = acceptance_policy(&conn)?;
+                // A failing check is evidence of breakage, not an absence of
+                // evidence, so policy alone never clears it.
+                let policy_allows = policy == checks::AcceptancePolicy::Advisory
+                    && verification == VERIFICATION_UNVERIFIED;
+                accepted_reason = match (request.allow_unverified, operator_reason, policy_allows) {
+                    (true, Some(reason), _) => Some(reason.to_string()),
+                    (true, None, _) => bail!(
+                        "INVALID_INPUT: accepting {verification} work requires an explicit reason; pass --override-reason to record why"
+                    ),
+                    (false, _, true) => verification_reason.map(str::to_string),
+                    // A failure and an absence need different advice: advisory
+                    // policy is the answer to "nothing to verify" and is never
+                    // the answer to "the check said no".
+                    (false, _, false) => {
+                        let remedy = if verification == VERIFICATION_FAILED {
+                            "Fix the failure and re-run the check, or record why it is being accepted anyway with `--allow-unverified --override-reason \"...\"`"
+                        } else {
+                            "Run a registered check against the current fingerprint, or, if this repository has nothing to verify, allow it once with `--allow-unverified --override-reason \"...\"` or for good with `foremerge checks policy advisory`"
+                        };
+                        bail!(
+                            "CHECK_FAILED: this ChangeSet is {verification} ({reason}). {remedy}",
+                            reason = verification_reason.unwrap_or("no validation on record")
+                        )
+                    }
+                };
             }
             let high: i64 = conn.query_row(
                 "SELECT COUNT(*) FROM conflicts WHERE severity = 'HIGH'
@@ -1547,20 +1784,23 @@ impl Foremerge {
         let mut conn = self.store.lock()?;
         let tx = Store::immediate_tx(&mut conn)?;
         let fresh = changeset_by_id(&tx, changeset_id)?;
-        require_state(&fresh.status, &["VALIDATED"], "accept")?;
+        require_state(&fresh.status, &["VALIDATED", "PROVISIONAL"], "accept")?;
         let fresh_intent = intent_by_id(&tx, &fresh.intent_id)?;
-        require_state(&fresh_intent.status, &["VALIDATED"], "accept")?;
-        let valid: Option<(bool, String)> = tx
-            .query_row(
-                "SELECT passed, fingerprint FROM validations WHERE changeset_id = ?1
-                 ORDER BY run_at DESC LIMIT 1",
-                [changeset_id],
-                |row| Ok((row.get(0)?, row.get(1)?)),
-            )
-            .optional()?;
-        match valid {
-            Some((true, fingerprint)) if fingerprint == fresh.fingerprint => {}
-            _ => bail!("CHECK_FAILED: no passing Foremerge validation for the current fingerprint"),
+        require_state(
+            &fresh_intent.status,
+            &["VALIDATED", "PROVISIONAL"],
+            "accept",
+        )?;
+        // Re-evaluated under the lock: the decision above was made before the
+        // transaction, so a validation could have landed or been superseded.
+        let (fresh_verification, _) = verification_state(&tx, changeset_id, &fresh.fingerprint)?;
+        if fresh_verification != verification {
+            bail!(
+                "CONFLICT: verification changed from {verification} to {fresh_verification} while accepting; retry"
+            );
+        }
+        if fresh_verification != VERIFICATION_VERIFIED && accepted_reason.is_none() {
+            bail!("CHECK_FAILED: no passing Foremerge validation for the current fingerprint");
         }
         let high: i64 = tx.query_row(
             "SELECT COUNT(*) FROM conflicts WHERE severity = 'HIGH'
@@ -1680,9 +1920,16 @@ impl Foremerge {
         let accepted_ref = git::create_accepted_ref(&worktree, changeset_id, &commit)?;
         let changed = tx.execute(
             "UPDATE changesets SET status = 'ACCEPTED', git_ref = ?2, accepted_commit = ?2,
-             integration_commit = NULL, updated_at = ?3
-             WHERE id = ?1 AND status = 'VALIDATED'",
-            params![changeset_id, commit, now],
+             integration_commit = NULL, acceptance_verification = ?4, acceptance_reason = ?5,
+             updated_at = ?3
+             WHERE id = ?1 AND status IN ('VALIDATED', 'PROVISIONAL')",
+            params![
+                changeset_id,
+                commit,
+                now,
+                verification,
+                accepted_reason.as_deref()
+            ],
         )?;
         if changed != 1 {
             bail!("STATE_RACE: ChangeSet changed while accepting it");
@@ -1692,7 +1939,7 @@ impl Foremerge {
             &tx,
             &changeset.intent_id,
             &changeset.agent_id,
-            "VALIDATED",
+            &fresh_intent.status,
             "ACCEPTED",
         )?;
         Store::append_event(
@@ -1701,10 +1948,14 @@ impl Foremerge {
             "ChangeSet",
             changeset_id,
             Some(&changeset.agent_id),
+            // The verification outcome rides in the immutable event too, so the
+            // audit trail states plainly what was and was not checked.
             &json!({
                 "git_ref": commit,
                 "accepted_commit": commit,
-                "accepted_ref": accepted_ref
+                "accepted_ref": accepted_ref,
+                "verification": verification,
+                "acceptance_reason": accepted_reason
             }),
         )?;
         tx.commit()?;
@@ -2189,11 +2440,27 @@ impl Foremerge {
             let agent = agent_by_id(&tx, agent_id)?;
             agent_names.insert(agent.id.clone(), agent.name.clone());
             if agent.status == "ACTIVE" {
+                // `last_seen_at` is maintained on the row but not carried on
+                // `Agent`, so it is read directly rather than widening a struct
+                // every other caller would then have to fill in.
+                let last_seen_at: String = tx.query_row(
+                    "SELECT last_seen_at FROM agents WHERE id = ?1",
+                    [&agent.id],
+                    |row| row.get(0),
+                )?;
+                let stale = DateTime::parse_from_rfc3339(&last_seen_at)
+                    .map(|seen| {
+                        Utc::now().signed_duration_since(seen).num_seconds()
+                            > AGENT_STALE_AFTER_SECONDS
+                    })
+                    .unwrap_or(false);
                 agents.push(StatusAgent {
                     id: agent.id,
                     name: agent.name,
                     model: agent.model,
                     worktree: agent.worktree,
+                    last_seen_at,
+                    stale,
                 });
             }
         }
@@ -2798,6 +3065,12 @@ pub fn validate_transition(from: &str, to: &str) -> Result<()> {
             | ("IN_PROGRESS", "PROVISIONAL")
             | ("PROVISIONAL", "VALIDATED")
             | ("VALIDATED", "ACCEPTED")
+            // Accepting straight from PROVISIONAL is how work with nothing to
+            // verify reaches a terminal state. It is not a way around the gate:
+            // acceptance still refuses unless the repository's policy permits
+            // unverified work or an operator records a reason, and the outcome
+            // is stored on the ChangeSet as UNVERIFIED or FAILED.
+            | ("PROVISIONAL", "ACCEPTED")
             | ("ACCEPTED", "COMMITTED")
     );
     if allowed {
@@ -2941,7 +3214,7 @@ fn changeset_by_id(conn: &Connection, id: &str) -> Result<ChangeSet> {
         "SELECT id, agent_id, task_id, intent_id, summary, files_json, symbols_json,
          contracts_json, dependencies_json, tests_json, decisions_json, provenance_json,
          base_ref, git_ref, accepted_commit, integration_commit, supersedes_changeset_id,
-         fingerprint, status, created_at, updated_at
+         fingerprint, status, acceptance_verification, acceptance_reason, created_at, updated_at
          FROM changesets WHERE id = ?1",
         [id],
         |row| {
@@ -2965,8 +3238,10 @@ fn changeset_by_id(conn: &Connection, id: &str) -> Result<ChangeSet> {
                 supersedes_changeset_id: row.get(16)?,
                 fingerprint: row.get(17)?,
                 status: row.get(18)?,
-                created_at: row.get(19)?,
-                updated_at: row.get(20)?,
+                acceptance_verification: row.get(19)?,
+                acceptance_reason: row.get(20)?,
+                created_at: row.get(21)?,
+                updated_at: row.get(22)?,
                 open_conflicts: None,
             })
         },

--- a/tests/benchmark_scenarios.rs
+++ b/tests/benchmark_scenarios.rs
@@ -231,6 +231,7 @@ async fn run_validation_gate(scenario: &Scenario) {
                 AcceptRequest {
                     git_ref: None,
                     allow_high_conflicts: false,
+                    allow_unverified: false,
                     override_reason: None,
                 },
             )

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -5141,3 +5141,254 @@ fn reopening_the_store_does_not_fabricate_extra_conflict_detections() {
         "the event log and the occurrence table must agree: {events}"
     );
 }
+
+/// Drive a repository to a published ChangeSet, returning (repo, agent, intent,
+/// changeset). Every test below needs the same runway.
+fn repo_with_published_changeset() -> (RepoFixture, String, String, String) {
+    let repo = create_repo();
+    let root = repo.root.clone();
+    cli_success(&root, None, ["init"]);
+    let agent = cli_success(
+        &root,
+        None,
+        [
+            "agent",
+            "register",
+            "--name",
+            "worker",
+            "--worktree",
+            root.to_str().unwrap(),
+        ],
+    )["data"]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let intent = cli_success(
+        &root,
+        None,
+        [
+            "intent",
+            "publish",
+            "--agent",
+            &agent,
+            "--task",
+            "t",
+            "--summary",
+            "Add a greeting helper",
+            "--scope",
+            "symbol:Greeter::greet",
+        ],
+    )["data"]["intent"]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    cli_success(
+        &root,
+        None,
+        [
+            "work",
+            "claim",
+            "--agent",
+            &agent,
+            "--intent",
+            &intent,
+            "--scope",
+            "symbol:Greeter::greet",
+        ],
+    );
+    cli_success(&root, None, ["work", "start", "--agent", &agent, &intent]);
+    fs::write(root.join("greeter.txt"), "greet\n").expect("write file");
+    git(&root, ["add", "-A"]);
+    git(&root, ["commit", "--quiet", "-m", "add greeter"]);
+    let changeset = cli_success(
+        &root,
+        None,
+        [
+            "changeset",
+            "publish",
+            "--agent",
+            &agent,
+            "--intent",
+            &intent,
+            "--summary",
+            "Adds a greeting helper",
+            "--file",
+            "greeter.txt",
+        ],
+    )["data"]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    (repo, agent, intent, changeset)
+}
+
+/// A repository with no test suite could not finish the lifecycle at all, and
+/// the only way through was to validate a no-op command, which wrote a passing
+/// validation into the append-only log for work nothing had checked.
+#[test]
+fn unverified_work_is_recorded_as_unverified_rather_than_faked() {
+    let (repo, _agent, _intent, changeset) = repo_with_published_changeset();
+    let root = repo.root.clone();
+
+    // Strict is the default, so this still refuses, but it now names the way out.
+    let refusal = cli_failure(&root, None, ["changeset", "accept", &changeset]);
+    let message = refusal["error"]["message"].as_str().unwrap();
+    assert!(message.contains("UNVERIFIED"), "{message}");
+    assert!(message.contains("--allow-unverified"), "{message}");
+
+    let accepted = cli_success(
+        &root,
+        None,
+        [
+            "changeset",
+            "accept",
+            &changeset,
+            "--allow-unverified",
+            "--override-reason",
+            "this repository has no test suite",
+        ],
+    );
+    assert_eq!(accepted["data"]["status"], "ACCEPTED");
+    assert_eq!(accepted["data"]["acceptance_verification"], "UNVERIFIED");
+    assert_eq!(
+        accepted["data"]["acceptance_reason"],
+        "this repository has no test suite"
+    );
+
+    // The immutable record must say the same thing, since that is the artifact
+    // an audit actually reads.
+    let events = cli_success(&root, None, ["events", "list", "--limit", "200"]);
+    let accepted_event = events["data"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|event| event["event_type"] == "changeset.accepted")
+        .expect("an acceptance event");
+    assert_eq!(accepted_event["payload"]["verification"], "UNVERIFIED");
+}
+
+/// An advisory policy is for repositories with nothing to verify. It must never
+/// wave through a check that ran and failed, which is evidence of breakage
+/// rather than an absence of evidence.
+#[test]
+fn an_advisory_policy_allows_unverified_work_but_never_a_failing_check() {
+    let (repo, _agent, _intent, changeset) = repo_with_published_changeset();
+    let root = repo.root.clone();
+    cli_success(&root, None, ["checks", "policy", "advisory"]);
+
+    // Nothing ran: permitted, and recorded honestly.
+    let accepted = cli_success(&root, None, ["changeset", "accept", &changeset]);
+    assert_eq!(accepted["data"]["acceptance_verification"], "UNVERIFIED");
+
+    // A check that ran and failed: refused under the same policy.
+    let (repo2, _a2, _i2, changeset2) = repo_with_published_changeset();
+    let root2 = repo2.root.clone();
+    cli_success(&root2, None, ["checks", "policy", "advisory"]);
+    cli_success(
+        &root2,
+        None,
+        ["changeset", "validate", &changeset2, "--", "false"],
+    );
+    let refusal = cli_failure(&root2, None, ["changeset", "accept", &changeset2]);
+    let message = refusal["error"]["message"].as_str().unwrap();
+    assert!(message.contains("FAILED"), "{message}");
+    // The remedy for a failure is to fix it, not to loosen the policy.
+    assert!(
+        !message.contains("checks policy advisory"),
+        "advisory policy must not be offered as the answer to a real failure: {message}"
+    );
+}
+
+/// An agent whose work outlasts its lease previously had no way to hold its
+/// claims, and lost collision protection silently.
+#[test]
+fn an_agent_can_renew_its_lease_while_working_without_stacking_claims() {
+    let repo = create_repo();
+    let root = repo.root.clone();
+    cli_success(&root, None, ["init"]);
+    let agent = cli_success(
+        &root,
+        None,
+        [
+            "agent",
+            "register",
+            "--name",
+            "worker",
+            "--worktree",
+            root.to_str().unwrap(),
+        ],
+    )["data"]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let intent = cli_success(
+        &root,
+        None,
+        [
+            "intent",
+            "publish",
+            "--agent",
+            &agent,
+            "--task",
+            "t",
+            "--summary",
+            "s",
+            "--scope",
+            "symbol:Greeter::greet",
+        ],
+    )["data"]["intent"]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let claim_args = [
+        "work",
+        "claim",
+        "--agent",
+        &agent,
+        "--intent",
+        &intent,
+        "--scope",
+        "symbol:Greeter::greet",
+    ];
+    let first = cli_success(&root, None, claim_args);
+    let first_lease = first["data"]["claims"][0]["lease_expires_at"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    cli_success(&root, None, ["work", "start", "--agent", &agent, &intent]);
+
+    // Renewing mid-work is the whole point: previously IN_PROGRESS was refused.
+    let renewed = cli_success(
+        &root,
+        None,
+        [
+            "work",
+            "claim",
+            "--agent",
+            &agent,
+            "--intent",
+            &intent,
+            "--scope",
+            "symbol:Greeter::greet",
+            "--lease-seconds",
+            "7200",
+        ],
+    );
+    let renewed_lease = renewed["data"]["claims"][0]["lease_expires_at"]
+        .as_str()
+        .unwrap();
+    assert!(
+        renewed_lease > first_lease.as_str(),
+        "lease should extend: {first_lease} -> {renewed_lease}"
+    );
+
+    // The same scope must not end up claimed twice, or `status` overstates what
+    // is actually held.
+    let status = cli_success(&root, None, ["status"]);
+    let claims = status["data"]["claims"].as_array().unwrap();
+    assert_eq!(
+        claims.len(),
+        1,
+        "renewal stacked a duplicate claim: {claims:?}"
+    );
+}


### PR DESCRIPTION
Closes the Foremerge project backlog: COR-489, COR-490, COR-491, COR-492, COR-493, COR-494, COR-498.

Every finding came from running parallel agents on a real repository and then verifying each claim against the store, rather than trusting the agents' own reports. Several of the agents' conclusions turned out to be wrong and are corrected below.

## The two that mattered

**Scope normalization (COR-489).** `Scope::canonical` only lowercased, so `App\Services\Report::render` and `Report::render` were different scopes forever. Agents describe the same method differently, so overlap detection silently failed for exactly the case it exists to catch. Symbol keys now reduce to `container::member` with namespace, module and path prefixes discarded.

The deliberate cost: two same-named classes in different namespaces now share a scope and can warn about each other. For an advisory system that is the right way to err, since a spurious warning is cheap and a missed collision is the failure the tool exists to prevent. Other scope kinds keep their key verbatim, because a path or a route is already unambiguous.

**Honest verification (COR-498).** A repository with no test suite could not finish the lifecycle at all, and the only way through was to validate a no-op command such as `true`. That wrote a *passing* validation into the append-only, hash-chained log for work nothing had checked. A gate that exists so an agent's word is never mistaken for evidence had, as its sole workaround, the fabrication of evidence.

Recording and enforcing are now separate. ChangeSets carry `VERIFIED`, `FAILED` or `UNVERIFIED` with a reason, on the record and in the acceptance event. `foremerge checks policy advisory` lets a repository with nothing to verify proceed honestly. A check that ran and **failed** is never cleared by policy, because a failure is evidence of breakage rather than an absence of evidence; that needs an explicit operator override, and agents still cannot override anything.

## The rest

- **COR-490 / COR-491** are the same `require_state` guard. An agent may now claim while `IN_PROGRESS`, which is how a long task renews its lease, and re-claiming extends the claim in place instead of stacking a duplicate row. `foremerge work adopt` transfers an intent whose agent has stopped, refused while any claim is still live so it can never take work from a busy agent.
- **COR-492** `status` stops counting silent agents as active, and marks an intent stranded when every claim has lapsed and its agent has gone quiet.
- **COR-493** `doctor` reports whether registered checks can actually run here, and warns when none are registered under a strict policy.
- **COR-494** opt-in advisory when a symbol scope names something that exists nowhere in the worktree.

## Migration

Schema 5 recomputes every stored canonical scope, rebuilding the projection from `intents.scopes_json` (the untouched source of truth) and recomputing claims in place. Where normalization makes two live claims on one intent share a scope, the longest-lived is kept.

Verified against a **copy** of a real schema-4 store: 107 events still audit `valid: true`, no rows lost, and `app\services\conversationcontextservice::buildsystemprompt` now normalizes to match its bare twin.

## Two agent claims I checked and disproved

- "Using `foremerge worktree create` instead of raw git would have avoided the missing-dependency problem." It would not. That command is a thin wrapper over `git worktree add` and carries no gitignored directories either. This is why the fix is a `doctor` check, not a docs note.
- `register_agent` genuinely is not idempotent, which I had missed. Filed separately as COR-503 rather than fixed here, because it needs a design decision.

## Verification

`make verify` and `make msrv` both pass. New tests cover normalization (including idempotency and that non-symbol scopes are untouched), the acceptance states, that advisory never clears a real failure, and that renewal extends without stacking.

One pre-existing timing test, `final_validation_snapshot_does_not_hold_the_coordination_write_lock`, fails under load average 500 and passes 3/3 in isolation. It is unrelated to these changes.