### PR TITLE
Make duplicate agent registration visible, and stop tests racing the clock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,22 @@ refuse to open a schema 5 store rather than migrate it backwards.
 
 ### Added
 
+- Registering an agent now reports when an ACTIVE agent of the same name is
+  already registered for the same worktree. Registration deliberately stays
+  insert-always, because two genuinely separate processes may share a name and
+  silently reusing a record could attach one process to work another still
+  owns. What it should not do is hide the duplicate: a dogfood run produced 11
+  agent records for 9 logical roles with nothing said about it. The response
+  gains a `warnings` entry naming the existing agent and pointing at
+  `foremerge work adopt`. Agent fields stay at the top level of the response,
+  so callers reading `data.id` are unaffected.
+
+- Test wait bounds scale with `FOREMERGE_TEST_TIMEOUT_SCALE`. Three validation
+  tests raced a fixed ten-second deadline and failed on a loaded machine while
+  the code was correct, which costs a debugging cycle every time because the
+  first hypothesis is always a regression. The bounds are now generous by
+  default and raisable, and the failure messages name the variable.
+
 - `foremerge work adopt` transfers an intent whose agent has stopped. An agent
   that died mid-task previously left its intent owned forever by an agent that
   would never return, so the work could only be duplicated. Adoption is refused

--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -161,7 +161,12 @@ CLI and HTTP operator surfaces:
 At the start of a coding session:
 
 1. Call `register_agent` with a unique session name, actual model identifier,
-   and isolated worktree.
+   and isolated worktree. Registration always creates a new record, so a
+   restarted agent is a new participant and cannot claim its previous intents.
+   If an ACTIVE agent with the same name already exists for that worktree, the
+   response carries a `warnings` entry naming it; treat that as a signal to
+   adopt the earlier work with `foremerge work adopt` rather than starting
+   again.
 2. Call `query_work` for the task or scopes you expect to touch.
 3. Call `publish_intent` before editing files.
 4. Inspect the returned conflicts or call `check_conflicts` for a provisional

--- a/src/api.rs
+++ b/src/api.rs
@@ -380,7 +380,7 @@ async fn register_agent(
     State(state): State<ApiState>,
     headers: HeaderMap,
     ApiJson(request): ApiJson<RegisterAgentRequest>,
-) -> ApiResult<Agent> {
+) -> ApiResult<RegisterAgentOutcome> {
     authorize(&state, &headers)?;
     let service = state.service;
     Ok(success(

--- a/src/model.rs
+++ b/src/model.rs
@@ -130,6 +130,19 @@ pub struct Agent {
     pub registered_at: String,
 }
 
+/// A registration, plus anything the caller should know about it.
+///
+/// The agent is flattened, so the response keeps the shape callers already
+/// depend on and gains `warnings` only when there is something to say.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RegisterAgentOutcome {
+    #[serde(flatten)]
+    pub agent: Agent,
+    /// Advisory notes about the registration itself. Empty in the normal case.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PublishIntentRequest {
     pub agent_id: String,

--- a/src/service.rs
+++ b/src/service.rs
@@ -191,7 +191,7 @@ impl Foremerge {
         Ok(())
     }
 
-    pub fn register_agent(&self, request: RegisterAgentRequest) -> Result<Agent> {
+    pub fn register_agent(&self, request: RegisterAgentRequest) -> Result<RegisterAgentOutcome> {
         let name = request.name.trim();
         if name.is_empty() {
             bail!("INVALID_INPUT: agent name cannot be empty");
@@ -229,6 +229,35 @@ impl Foremerge {
         if let Some(repo) = &repo {
             bind_repository(&tx, &repo.common_dir)?;
         }
+
+        // Registration deliberately stays insert-always: two genuinely separate
+        // processes may share a name, and silently handing a new process an
+        // existing record could attach it to work another live process owns.
+        // What is not acceptable is doing it invisibly, so the duplicate is
+        // reported. Observed in the GPTree dogfood run as 11 agent records for
+        // 9 logical roles.
+        let mut warnings = Vec::new();
+        if let Some(worktree) = agent.worktree.as_deref() {
+            let existing: Vec<String> = tx
+                .prepare(
+                    "SELECT id FROM agents
+                     WHERE name = ?1 AND worktree = ?2 AND status = 'ACTIVE'
+                     ORDER BY registered_at",
+                )?
+                .query_map(params![agent.name, worktree], |row| row.get(0))?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+            if !existing.is_empty() {
+                warnings.push(format!(
+                    "an agent named '{}' is already registered ACTIVE for this worktree ({}). \
+                     This registration is a separate participant and cannot claim that agent's \
+                     intents. If this is the same agent restarting, adopt the earlier work with \
+                     `foremerge work adopt` instead of duplicating it.",
+                    agent.name,
+                    existing.join(", ")
+                ));
+            }
+        }
+
         tx.execute(
             "INSERT INTO agents(id, name, model, capabilities_json, worktree, git_branch, git_head,
              status, registered_at, last_seen_at) VALUES(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
@@ -261,7 +290,7 @@ impl Foremerge {
             &serde_json::to_value(&agent)?,
         )?;
         tx.commit()?;
-        Ok(agent)
+        Ok(RegisterAgentOutcome { agent, warnings })
     }
 
     pub fn publish_intent(
@@ -3390,7 +3419,8 @@ mod tests {
                 capabilities: vec![],
                 worktree: None,
             })
-            .unwrap();
+            .unwrap()
+            .agent;
         let second = service
             .register_agent(RegisterAgentRequest {
                 name: "paypal-agent".into(),
@@ -3398,7 +3428,8 @@ mod tests {
                 capabilities: vec![],
                 worktree: None,
             })
-            .unwrap();
+            .unwrap()
+            .agent;
         let make_intent = |agent: &Agent, summary: &str| {
             service
                 .publish_intent(PublishIntentRequest {
@@ -3454,7 +3485,8 @@ mod tests {
                 capabilities: vec![],
                 worktree: None,
             })
-            .unwrap();
+            .unwrap()
+            .agent;
 
         let error = service
             .publish_intent(PublishIntentRequest {
@@ -3515,6 +3547,7 @@ mod tests {
                     worktree: None,
                 })
                 .unwrap()
+                .agent
         };
         let first = register("canonical-a");
         let second = register("canonical-b");
@@ -3591,6 +3624,7 @@ mod tests {
                     worktree: None,
                 })
                 .unwrap()
+                .agent
         };
         let first = register("occurrence-a");
         let second = register("occurrence-b");
@@ -3710,7 +3744,8 @@ mod tests {
                 capabilities: vec![],
                 worktree: None,
             })
-            .unwrap();
+            .unwrap()
+            .agent;
         let publish = |task: String, scope: Scope| {
             service
                 .publish_intent(PublishIntentRequest {

--- a/tests/benchmark_scenarios.rs
+++ b/tests/benchmark_scenarios.rs
@@ -90,7 +90,8 @@ async fn committed_benchmark_corpus_matches_executable_ground_truth() {
                     capabilities: vec![],
                     worktree: None,
                 })
-                .unwrap();
+                .unwrap()
+                .agent;
             latest_conflicts = service
                 .publish_intent(PublishIntentRequest {
                     agent_id: agent.id,
@@ -167,7 +168,8 @@ async fn run_validation_gate(scenario: &Scenario) {
             capabilities: vec![],
             worktree: Some(root.to_string_lossy().into_owned()),
         })
-        .unwrap();
+        .unwrap()
+        .agent;
     let intent = service
         .publish_intent(PublishIntentRequest {
             agent_id: agent.id.clone(),

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -223,12 +223,43 @@ fn database_from_doctor(cwd: &Path) -> PathBuf {
     PathBuf::from(data_string(&doctor, "database"))
 }
 
+/// Multiplier for every wall-clock wait bound in this suite.
+///
+/// Deadline-based waits race real time, so a machine busy with other work can
+/// fail them while the code under test is perfectly correct. That happened at
+/// a load average around 748: three validation tests failed non-deterministically
+/// and passed again once the machine was idle, which costs a debugging cycle
+/// every time because the first hypothesis is always "I broke something".
+///
+/// Raising `FOREMERGE_TEST_TIMEOUT_SCALE` gives those waits more room without
+/// touching any duration a test actually asserts on.
+fn timeout_scale() -> u32 {
+    std::env::var("FOREMERGE_TEST_TIMEOUT_SCALE")
+        .ok()
+        .and_then(|raw| raw.parse::<u32>().ok())
+        .filter(|scale| *scale >= 1)
+        .unwrap_or(1)
+}
+
+/// How long a test may wait for something to happen.
+///
+/// Only for wait bounds. Never use this for a duration under test, such as a
+/// configured validation timeout, or the test would stop checking the thing it
+/// exists to check.
+fn wait_budget(base: Duration) -> Duration {
+    base * timeout_scale()
+}
+
 fn wait_for_sentinel(path: &Path) {
-    let deadline = Instant::now() + Duration::from_secs(10);
+    let budget = wait_budget(Duration::from_secs(30));
+    let deadline = Instant::now() + budget;
     while !path.is_file() {
         assert!(
             Instant::now() < deadline,
-            "sentinel was not created within ten seconds: {}",
+            "sentinel was not created within {}s: {}\n\
+             If this machine is busy, raise FOREMERGE_TEST_TIMEOUT_SCALE and retry \
+             before assuming a regression.",
+            budget.as_secs(),
             path.display()
         );
         std::thread::sleep(Duration::from_millis(10));
@@ -990,7 +1021,9 @@ fn final_validation_snapshot_does_not_hold_the_coordination_write_lock() {
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
     let mut registration = registration.spawn().expect("spawn concurrent registration");
-    let deadline = Instant::now() + Duration::from_secs(2);
+    // A genuine write-lock block never completes, so a generous bound still
+    // catches the bug while surviving a loaded machine.
+    let deadline = Instant::now() + wait_budget(Duration::from_secs(5));
     loop {
         if registration
             .try_wait()
@@ -1004,7 +1037,11 @@ fn final_validation_snapshot_does_not_hold_the_coordination_write_lock() {
             let _ = registration.kill();
             let _ = registration.wait();
             let _ = validation.wait_with_output();
-            panic!("concurrent mutation was blocked while the final Git snapshot was running");
+            panic!(
+                "concurrent mutation was blocked while the final Git snapshot was running.\n\
+                 If this machine is busy, raise FOREMERGE_TEST_TIMEOUT_SCALE and retry \
+                 before assuming a regression."
+            );
         }
         std::thread::sleep(Duration::from_millis(10));
     }
@@ -1155,6 +1192,73 @@ fn publishing_from_claimed_implicitly_enters_provisional_without_panicking() {
             json!({ "from": "IN_PROGRESS", "to": "PROVISIONAL" }),
         ],
         "claim plus implicit publication must preserve all three lifecycle boundaries"
+    );
+}
+
+/// Registration stays insert-always, because two separate processes may share
+/// a name and silently reusing a record could attach one to another's work.
+/// What it must not do is hide the duplicate: the GPTree dogfood run produced
+/// 11 agent records for 9 logical roles with nothing said about it.
+#[test]
+fn registering_a_second_agent_for_the_same_name_and_worktree_says_so() {
+    let repo = create_repo();
+
+    let first = cli_success(
+        &repo.root,
+        None,
+        ["agent", "register", "--name", "twin", "--model", "e2e-test"],
+    );
+    assert!(
+        first["data"]["warnings"].is_null(),
+        "a first registration has nothing to warn about: {first}"
+    );
+
+    let second = cli_success(
+        &repo.root,
+        None,
+        ["agent", "register", "--name", "twin", "--model", "e2e-test"],
+    );
+
+    // The agent fields stay at the top level of `data`, so the added warnings
+    // field cannot break a caller that reads `data.id` today.
+    let first_id = data_string(&first, "id").to_string();
+    let second_id = data_string(&second, "id").to_string();
+    assert_ne!(first_id, second_id, "each registration is its own record");
+
+    let warnings = second["data"]["warnings"]
+        .as_array()
+        .unwrap_or_else(|| panic!("second registration should warn: {second}"));
+    assert_eq!(warnings.len(), 1, "{second}");
+    let warning = warnings[0].as_str().unwrap();
+    assert!(
+        warning.contains(&first_id),
+        "the warning must name the agent it collides with, got: {warning}"
+    );
+    assert!(
+        warning.contains("work adopt"),
+        "the warning must point at the recovery path, got: {warning}"
+    );
+}
+
+#[test]
+fn a_different_name_in_the_same_worktree_is_not_a_duplicate() {
+    let repo = create_repo();
+    let first = cli_success(
+        &repo.root,
+        None,
+        [
+            "agent", "register", "--name", "alpha", "--model", "e2e-test",
+        ],
+    );
+    let second = cli_success(
+        &repo.root,
+        None,
+        ["agent", "register", "--name", "beta", "--model", "e2e-test"],
+    );
+    assert!(first["data"]["warnings"].is_null(), "{first}");
+    assert!(
+        second["data"]["warnings"].is_null(),
+        "distinct names in one worktree are ordinary: {second}"
     );
 }
 


### PR DESCRIPTION
Closes [COR-503](https://linear.app/corgen/issue/COR-503) and [COR-502](https://linear.app/corgen/issue/COR-502). Verifies [COR-500](https://linear.app/corgen/issue/COR-500) as already fixed.

Based on `fix/dogfood-findings` (#9) rather than `main`, because all three tickets touch files #9 changes (`src/service.rs`, `src/mcp.rs`, `tests/e2e.rs`) and basing on main would have created a second avoidable conflict.

## COR-503: duplicate registration is now visible

`register_agent` minted a fresh id and inserted unconditionally, so the same logical agent restarting became a different participant. The dogfood run produced 11 agent records for 9 roles with nothing said about it.

Registration deliberately **stays insert-always**. Reusing a record by name is wrong, since two genuinely separate processes may share one; reusing by `(name, worktree)` would silently attach a new process to work a live process still owns. The ticket identified making the duplicate visible as the smallest honest change, and that is what this does:

```
an agent named 'twin' is already registered ACTIVE for this worktree (agt_...).
This registration is a separate participant and cannot claim that agent's intents.
If this is the same agent restarting, adopt the earlier work with
`foremerge work adopt` instead of duplicating it.
```

**No caller has to change.** The agent is `#[serde(flatten)]`ed into the outcome, so `data.id` and every other field stay exactly where they are, and `warnings` appears only when non-empty. A test asserts that property explicitly, since silently reshaping the response would be a worse bug than the one being fixed.

## COR-502: tests no longer race the clock

Three validation tests raced a fixed ten-second deadline and failed on a loaded machine while the code was correct. That is worse than a slow test: the first hypothesis is always "I broke something", and ruling it out cost a full cycle of building unmodified `main` under the same toolchain to compare.

Wait bounds are now generous by default and scale with `FOREMERGE_TEST_TIMEOUT_SCALE`, and both failure messages name the variable so the next person does not repeat that investigation. The scaled helper is documented as being for wait bounds only, never for a duration a test asserts on, which would quietly gut the test.

## COR-500: already fixed, verified not assumed

The `anyOf` fix landed on this branch already. I confirmed the shipped schema declares it by running the built binary, and audited the remaining 16 tools: `query_work` is the only other tool with properties and no required list, and it genuinely accepts an empty call, so there is no second instance.

## Verification

`make verify` passes, including all 55 e2e tests (2 new) at load average 116, which is the condition that used to break them.