### PR TITLE
Stop reading a stray destructive verb as a threat to a shared scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,17 @@ refuse to open a schema 5 store rather than migrate it backwards.
   prints guidance to stderr on startup, and answers a bare tool name with the
   equivalent JSON-RPC line. Both are suppressed when stdin is a pipe, so client
   sessions are byte for byte unchanged.
+- `tests/paraphrase_probe.rs`, an adversarial gate over the intent detector. It
+  restates one genuine conflict in ten phrasings while holding the declared
+  scopes identical, so every miss is a paraphrase failure, and pairs genuinely
+  compatible work with destructive keywords on a shared scope, so every HIGH is
+  a false alarm. The build fails if compatible work ever raises a HIGH again or
+  if paraphrase coverage falls below its recorded floor. Per
+  `docs/benchmark-plan.md`, raising that floor by tuning the vocabulary against
+  this file does not count as an improvement; held-back phrasings do.
+- `tests/full_flow_probe.rs`, which reports every warning two agents actually
+  receive across register, publish, and claim, rather than the output of a
+  single detector call.
 
 ### Fixed
 
@@ -99,6 +110,31 @@ refuse to open a schema 5 store rather than migrate it backwards.
   status never expired, so a fleet that died hours earlier still reported as
   fully working; agents unseen for over two hours are now shown as silent and
   excluded from the active count. Claims already expired correctly.
+- A destructive verb anywhere in an intent summary no longer implies that the
+  destruction applies to a shared semantic scope. The detector previously read
+  "Delete the flaky ThumbnailCache benchmark test" as a removal of
+  `ThumbnailCache` itself, and paired it with any additive intent on the same
+  scope to raise a HIGH replace-versus-extend conflict. The explanation it
+  produced was false, and a false HIGH is worse than silence: severity is the
+  signal an agent uses to decide what to stop for, so crying wolf at the top
+  severity trains agents to ignore it. Two structural checks now gate that
+  finding. The verb must not govern only a peripheral artefact, because
+  deleting a test, retiring a feature flag, or dropping a debug counter does
+  not change the contract of the component it is named after. The scope must
+  also be the object of the verb rather than a modifier inside it, because
+  "Move the ThumbnailCache eviction loop into a background task" moves the
+  loop, not the cache. When either check trips, the pair is still reported, at
+  MEDIUM, as a shared semantic scope. Nothing goes unreported; the detector
+  simply stops asserting an incompatibility it cannot support.
+- Widened the operation vocabulary so that common phrasings of the same
+  conflict are classified rather than ignored. Detection requires a known verb
+  on both sides, so coverage was the product of two incomplete word lists and a
+  single unfamiliar word on either side silenced the pair entirely. This is a
+  bounded improvement and not a general solution: a fixed vocabulary cannot
+  cover English, and the remaining misses are words that have not been added
+  yet rather than a different class of problem. Deciding whether intent
+  classification should stay lexical is tracked separately.
+
 
 ## [0.3.1] - 2026-08-24
 

--- a/src/conflict.rs
+++ b/src/conflict.rs
@@ -124,6 +124,222 @@ fn infer(summary: &str, scopes: &[Scope]) -> Inference {
     }
 }
 
+/// Nouns naming an artefact whose removal or rename never changes the contract
+/// of the thing it belongs to. Deleting a test, retiring a feature flag, or
+/// dropping a debug counter is not destroying the component the artefact is
+/// named after, so a destructive verb governing one of these must not be read
+/// as a threat to a shared semantic scope. This list is deliberately small and
+/// closed: it names peripheral artefacts, which are a stable category, rather
+/// than trying to enumerate destructive verbs, which are not.
+const PERIPHERAL_ARTIFACTS: &[&str] = &[
+    "test",
+    "tests",
+    "spec",
+    "specs",
+    "benchmark",
+    "benchmarks",
+    "fixture",
+    "fixtures",
+    "mock",
+    "mocks",
+    "stub",
+    "stubs",
+    "flag",
+    "flags",
+    "counter",
+    "counters",
+    "metric",
+    "metrics",
+    "log",
+    "logs",
+    "logging",
+    "comment",
+    "comments",
+    "docstring",
+    "todo",
+    "variable",
+    "variables",
+    "import",
+    "imports",
+    "dead",
+    "unused",
+    "lint",
+    "typo",
+    "whitespace",
+];
+
+/// Words that end the phrase a verb governs. Everything after one of these
+/// describes where the work happens, not what is being changed, so
+/// `drop the unused debug counter from ThumbnailCache` governs the counter
+/// and merely mentions the cache.
+const OBJECT_BOUNDARY: &[&str] = &[
+    "in",
+    "into",
+    "inside",
+    "within",
+    "from",
+    "to",
+    "onto",
+    "on",
+    "at",
+    "for",
+    "with",
+    "by",
+    "under",
+    "behind",
+    "across",
+    "over",
+    "around",
+    "guarding",
+    "protecting",
+    "covering",
+    "so",
+    "then",
+    "and",
+];
+
+/// Words that name the same entity as the identifier immediately before them,
+/// so `the users.email column` and `the PaymentService class` still refer to
+/// the scope itself rather than to something merely named after it.
+const TRANSPARENT_HEAD: &[&str] = &[
+    "class",
+    "service",
+    "module",
+    "struct",
+    "type",
+    "interface",
+    "component",
+    "implementation",
+    "impl",
+    "object",
+    "model",
+    "entity",
+    "record",
+    "table",
+    "column",
+    "field",
+    "api",
+    "endpoint",
+    "abstraction",
+    "layer",
+];
+
+/// Words that carry no noun of their own and so never end a governed phrase.
+const PHRASE_FILLER: &[&str] = &[
+    "a",
+    "an",
+    "the",
+    "its",
+    "their",
+    "our",
+    "all",
+    "any",
+    "some",
+    "this",
+    "that",
+    "these",
+    "those",
+    "legacy",
+    "old",
+    "new",
+    "existing",
+    "current",
+    "obsolete",
+    "flaky",
+    "confusing",
+    "local",
+    "debug",
+];
+
+/// The phrase a destructive verb governs: everything after the first
+/// destructive keyword, stopping at a clause boundary or punctuation. Returns
+/// words in their original case so scope identifiers stay comparable.
+fn governed_phrase(summary: &str, operation: Operation) -> Option<Vec<String>> {
+    if !operation.destructive() {
+        return None;
+    }
+    let keywords = OPERATION_BUCKETS
+        .iter()
+        .find(|(bucket, _)| *bucket == operation)
+        .map(|(_, keywords)| *keywords)?;
+
+    let trim = |word: &str| {
+        word.trim_matches(|character: char| {
+            !character.is_ascii_alphanumeric()
+                && character != '.'
+                && character != '_'
+                && character != ':'
+        })
+        .to_string()
+    };
+
+    let mut phrase = Vec::new();
+    let mut seen_verb = false;
+    for raw in summary.split_whitespace() {
+        let word = trim(raw);
+        if word.is_empty() {
+            continue;
+        }
+        let lowered = word.to_ascii_lowercase();
+        if !seen_verb {
+            seen_verb = keywords.contains(&lowered.as_str());
+            continue;
+        }
+        if OBJECT_BOUNDARY.contains(&lowered.as_str()) {
+            break;
+        }
+        phrase.push(word);
+        // A sentence or clause ending closes the phrase.
+        if raw.ends_with([',', ';', '.', ')']) {
+            break;
+        }
+    }
+    if !seen_verb || phrase.is_empty() {
+        return None;
+    }
+    Some(phrase)
+}
+
+/// Does the destructive verb govern only a peripheral artefact?
+///
+/// `Delete the flaky ThumbnailCache benchmark test` destroys a test, not the
+/// cache. Used to hold back the HIGH replace-versus-extend finding without
+/// silencing the pair: the caller still reports the overlap at MEDIUM.
+fn destructive_object_is_peripheral(summary: &str, operation: Operation) -> bool {
+    let Some(phrase) = governed_phrase(summary, operation) else {
+        return false;
+    };
+    phrase
+        .iter()
+        .any(|word| PERIPHERAL_ARTIFACTS.contains(&word.to_ascii_lowercase().as_str()))
+}
+
+/// Is the shared scope only a modifier inside the governed phrase?
+///
+/// `Move the ThumbnailCache eviction loop into a background task` governs the
+/// loop; `ThumbnailCache` qualifies which loop. The scope counts as the real
+/// object only when nothing but transparent head nouns follows it.
+fn scope_is_modifier_in_object(summary: &str, operation: Operation, scope: &Scope) -> bool {
+    let Some(phrase) = governed_phrase(summary, operation) else {
+        return false;
+    };
+    let scope_tokens = tokenize(&scope.key);
+    let Some(position) = phrase.iter().rposition(|word| {
+        // Require the word to carry the whole key. A partial token hit
+        // ("payment" against `PaymentService`) is a topical match, not a
+        // naming of the scope, and must not suppress anything.
+        !scope_tokens.is_empty() && scope_tokens.is_subset(&tokenize(word))
+    }) else {
+        // The scope is not inside the governed phrase at all, so this rule
+        // does not apply and must not suppress anything.
+        return false;
+    };
+    phrase[position + 1..].iter().any(|word| {
+        let lowered = word.to_ascii_lowercase();
+        !TRANSPARENT_HEAD.contains(&lowered.as_str()) && !PHRASE_FILLER.contains(&lowered.as_str())
+    })
+}
+
 /// Operation buckets in destructive-priority order: a destructive keyword
 /// anywhere in the summary outranks additive phrasing around it, so "Add a
 /// migration to drop the legacy users.email column" classifies as remove.
@@ -132,12 +348,53 @@ fn infer(summary: &str, scopes: &[Scope]) -> Inference {
 const OPERATION_BUCKETS: &[(Operation, &[&str])] = &[
     (
         Operation::Replace,
-        &["replace", "rewrite", "supersede", "swap"],
+        &[
+            "replace",
+            "rewrite",
+            "supersede",
+            "swap",
+            "consolidate",
+            "unify",
+            "standardize",
+            "standardise",
+            "collapse",
+            "reimplement",
+            "overhaul",
+        ],
     ),
-    (Operation::Remove, &["remove", "delete", "drop", "retire"]),
+    (
+        Operation::Remove,
+        &[
+            "remove",
+            "delete",
+            "drop",
+            "retire",
+            "deprecate",
+            "sunset",
+            "decommission",
+            "eliminate",
+        ],
+    ),
     (Operation::Rename, &["rename", "move"]),
     (Operation::Migrate, &["migrate", "convert"]),
-    (Operation::Extend, &["extend", "augment"]),
+    (
+        Operation::Extend,
+        &[
+            "extend",
+            "augment",
+            "back",
+            "wire",
+            "plug",
+            "teach",
+            "expose",
+            "enable",
+            "offer",
+            "accept",
+            "allow",
+            "integrate",
+            "hook",
+        ],
+    ),
     (Operation::Add, &["add", "introduce", "implement", "create"]),
     (
         Operation::Modify,
@@ -449,12 +706,62 @@ pub fn detect_pair(source: &IntentCandidate, target: &IntentCandidate) -> Vec<Co
             && target_inference.operation.additive())
             || (target_inference.operation.destructive() && source_inference.operation.additive());
         if operations_collide {
-            let (destructive, additive, destructive_scope) =
+            let (destructive, additive, destructive_scope, destructive_summary) =
                 if source_inference.operation.destructive() {
-                    (&source_inference, &target_inference, &overlap.source)
+                    (
+                        &source_inference,
+                        &target_inference,
+                        &overlap.source,
+                        source.summary.as_str(),
+                    )
                 } else {
-                    (&target_inference, &source_inference, &overlap.target)
+                    (
+                        &target_inference,
+                        &source_inference,
+                        &overlap.target,
+                        target.summary.as_str(),
+                    )
                 };
+            // A destructive verb that governs only a peripheral artefact does
+            // not threaten the shared scope. Report the overlap, but do not
+            // claim one agent is removing what the other is extending: that
+            // explanation would be false, and a false HIGH trains agents to
+            // ignore the severity that matters.
+            if destructive_object_is_peripheral(destructive_summary, destructive.operation)
+                || scope_is_modifier_in_object(
+                    destructive_summary,
+                    destructive.operation,
+                    destructive_scope,
+                )
+            {
+                results.push(make_conflict(
+                    "shared_semantic_scope",
+                    "MEDIUM",
+                    (scope_score * 0.7).min(0.8),
+                    source,
+                    target,
+                    Some(scope.clone()),
+                    format!(
+                        "Both intents reference `{}` ({}), but the {} applies to a peripheral artefact rather than to `{}` itself.",
+                        scope.key,
+                        overlap.describe(),
+                        destructive.operation.as_str(),
+                        scope.key
+                    ),
+                    "Confirm the peripheral change is not load-bearing for the other intent, then proceed. Claims remain advisory."
+                        .to_string(),
+                    json!({
+                        "rule": "FM-C003",
+                        "downgraded_from": "replace_vs_extend",
+                        "reason": "destructive verb does not govern the shared scope",
+                        "source_operation": source_inference.operation.as_str(),
+                        "target_operation": target_inference.operation.as_str(),
+                        "source_scope": overlap.source.canonical(),
+                        "target_scope": overlap.target.canonical(),
+                    }),
+                ));
+                return results;
+            }
             let score =
                 (scope_score * destructive.confidence.min(additive.confidence) * 1.02).min(0.99);
             let suggestion = if let Some(migration) = overlap.migration_scope() {

--- a/tests/full_flow_probe.rs
+++ b/tests/full_flow_probe.rs
@@ -1,0 +1,150 @@
+//! What does an agent ACTUALLY receive end to end? Registers two agents,
+//! publishes both intents, then has both claim their scopes, exactly as a
+//! real coordinated run would. Prints every warning either agent sees.
+
+use foremerge::model::*;
+use foremerge::{Foremerge, Store};
+
+fn scope(kind: &str, key: &str) -> Scope {
+    Scope {
+        kind: kind.into(),
+        key: key.into(),
+    }
+}
+
+fn run(label: &str, a: (&str, &str, Vec<Scope>), b: (&str, &str, Vec<Scope>)) {
+    let service = Foremerge::new(Store::in_memory().unwrap());
+    let mut seen: Vec<(String, String, String)> = Vec::new();
+
+    for (who, task, summary, scopes) in [
+        ("agent-a", a.0, a.1, a.2.clone()),
+        ("agent-b", b.0, b.1, b.2.clone()),
+    ] {
+        let agent = service
+            .register_agent(RegisterAgentRequest {
+                name: who.into(),
+                model: Some("probe".into()),
+                capabilities: vec![],
+                worktree: None,
+            })
+            .unwrap()
+            .agent;
+
+        let published = service
+            .publish_intent(PublishIntentRequest {
+                agent_id: agent.id.clone(),
+                task: task.into(),
+                summary: summary.into(),
+                rationale: None,
+                scopes: scopes.clone(),
+                depends_on: vec![],
+                metadata: serde_json::json!({}),
+            })
+            .unwrap();
+        for c in &published.conflicts {
+            seen.push((format!("{who} publish"), c.severity.clone(), c.kind.clone()));
+        }
+
+        let claimed = service
+            .claim_work(ClaimWorkRequest {
+                agent_id: agent.id,
+                intent_id: published.intent.id,
+                scopes,
+                reason: None,
+                lease_seconds: 3600,
+            })
+            .unwrap();
+        for c in &claimed.warnings {
+            seen.push((format!("{who} claim"), c.severity.clone(), c.kind.clone()));
+        }
+    }
+
+    println!("\n--- {label} ---");
+    if seen.is_empty() {
+        println!("  (no warning of any kind)");
+    }
+    for (stage, severity, kind) in seen {
+        println!("  {:<16} {:<7} {}", stage, severity, kind);
+    }
+}
+
+#[test]
+fn full_flow_probe() {
+    let pay = vec![
+        scope("symbol", "PaymentService"),
+        scope("contract", "payments.provider"),
+    ];
+
+    run(
+        "A1 REAL CONFLICT, in-vocab wording (your demo)",
+        (
+            "Modernize payments",
+            "Replace PaymentService with StripePaymentService",
+            pay.clone(),
+        ),
+        (
+            "Add payment option",
+            "Add PayPal support to PaymentService",
+            pay.clone(),
+        ),
+    );
+
+    run(
+        "A2 SAME REAL CONFLICT, reworded",
+        (
+            "Modernize payments",
+            "Consolidate all payment handling onto Stripe in PaymentService",
+            pay.clone(),
+        ),
+        (
+            "Add payment option",
+            "Back PaymentService with an additional PayPal gateway",
+            pay.clone(),
+        ),
+    );
+
+    run(
+        "A3 SAME REAL CONFLICT, reworded again",
+        (
+            "Modernize payments",
+            "Cut PaymentService over to Stripe exclusively",
+            pay.clone(),
+        ),
+        (
+            "Add payment option",
+            "Teach PaymentService to accept PayPal payments",
+            pay.clone(),
+        ),
+    );
+
+    let cache = vec![scope("component", "ThumbnailCache")];
+
+    run(
+        "B1 NO CONFLICT, harmless work, same scope",
+        (
+            "Clean up tests",
+            "Delete the flaky ThumbnailCache benchmark test",
+            cache.clone(),
+        ),
+        (
+            "Bound the cache",
+            "Implement a size limit for ThumbnailCache",
+            cache.clone(),
+        ),
+    );
+
+    run(
+        "B2 NO CONFLICT, harmless work, DISJOINT scopes",
+        (
+            "Clean up tests",
+            "Delete the flaky ThumbnailCache benchmark test",
+            vec![scope("file", "tests/thumbnail_bench.rs")],
+        ),
+        (
+            "Bound the cache",
+            "Implement a size limit for ThumbnailCache",
+            vec![scope("symbol", "ThumbnailCache")],
+        ),
+    );
+    println!();
+}

--- a/tests/paraphrase_probe.rs
+++ b/tests/paraphrase_probe.rs
@@ -1,0 +1,259 @@
+//! Adversarial probe for the intent detector.
+//!
+//! The detector decides severity from the verbs an agent happens to use. This
+//! test measures how far that generalises, in both directions:
+//!
+//! * **Set A** restates one genuine replace-versus-extend conflict ten ways,
+//!   holding the declared scopes identical, so every miss is a paraphrase
+//!   failure and nothing else.
+//! * **Sets B and C** are pairs of genuinely compatible work that mention a
+//!   shared scope while containing destructive keywords. Every HIGH here is a
+//!   false alarm, and a false HIGH is worse than silence: it trains agents to
+//!   ignore the one severity that is supposed to stop them.
+//!
+//! The gate below asserts only the property that generalises (no false HIGH)
+//! plus a floor on Set A to catch regressions. Raising that floor by adding
+//! more verbs to `OPERATION_BUCKETS` would be tuning against this file, which
+//! `docs/benchmark-plan.md` explicitly forbids. Paraphrases held back from
+//! this file are the real measure.
+
+use foremerge::conflict::{IntentCandidate, detect_pair};
+use foremerge::model::Scope;
+
+struct Pair {
+    label: &'static str,
+    left: &'static str,
+    left_scopes: Vec<Scope>,
+    right: &'static str,
+    right_scopes: Vec<Scope>,
+}
+
+fn scope(kind: &str, key: &str) -> Scope {
+    Scope {
+        kind: kind.into(),
+        key: key.into(),
+    }
+}
+
+fn payment_scopes() -> Vec<Scope> {
+    vec![
+        scope("symbol", "PaymentService"),
+        scope("contract", "payments.provider"),
+    ]
+}
+
+fn cache_scopes() -> Vec<Scope> {
+    vec![scope("component", "ThumbnailCache")]
+}
+
+/// Same declared scopes on both sides; only the wording differs.
+fn symmetric(label: &'static str, left: &'static str, right: &'static str, s: Vec<Scope>) -> Pair {
+    Pair {
+        label,
+        left,
+        left_scopes: s.clone(),
+        right,
+        right_scopes: s,
+    }
+}
+
+/// Highest severity either agent sees, in both publish orders.
+fn worst(pair: &Pair) -> (String, String) {
+    let left = IntentCandidate {
+        id: "a".into(),
+        summary: pair.left.into(),
+        scopes: pair.left_scopes.clone(),
+    };
+    let right = IntentCandidate {
+        id: "b".into(),
+        summary: pair.right.into(),
+        scopes: pair.right_scopes.clone(),
+    };
+    let mut all = detect_pair(&left, &right);
+    all.extend(detect_pair(&right, &left));
+    all.iter()
+        .max_by_key(|conflict| match conflict.severity.as_str() {
+            "HIGH" => 3,
+            "MEDIUM" => 2,
+            "LOW" => 1,
+            _ => 0,
+        })
+        .map(|conflict| (conflict.severity.clone(), conflict.kind.clone()))
+        .unwrap_or_else(|| ("NONE".into(), "-".into()))
+}
+
+fn report(title: &str, pairs: &[Pair]) -> (usize, usize) {
+    println!("\n=== {title} ===");
+    let mut high = 0;
+    let mut any = 0;
+    for pair in pairs {
+        let (severity, kind) = worst(pair);
+        if severity == "HIGH" {
+            high += 1;
+        }
+        if severity != "NONE" {
+            any += 1;
+        }
+        println!("  {:<28} {severity:<7} {kind}", pair.label);
+    }
+    (high, any)
+}
+
+#[test]
+fn paraphrase_probe() {
+    // Set A: every pair is the same genuine conflict as fixture 01.
+    let set_a = vec![
+        symmetric(
+            "baseline (in-vocabulary)",
+            "Replace PaymentService with StripePaymentService",
+            "Add PayPal support to PaymentService",
+            payment_scopes(),
+        ),
+        symmetric(
+            "consolidate / back with",
+            "Consolidate all payment handling onto Stripe in PaymentService",
+            "Back PaymentService with an additional PayPal gateway",
+            payment_scopes(),
+        ),
+        symmetric(
+            "port / wire up",
+            "Port PaymentService over to the Stripe SDK",
+            "Wire up PayPal as another option in PaymentService",
+            payment_scopes(),
+        ),
+        symmetric(
+            "cut over / teach",
+            "Cut PaymentService over to Stripe exclusively",
+            "Teach PaymentService to accept PayPal payments",
+            payment_scopes(),
+        ),
+        symmetric(
+            "deprecate / expose",
+            "Deprecate the current PaymentService internals in favour of Stripe",
+            "Expose a PayPal path through PaymentService",
+            payment_scopes(),
+        ),
+        symmetric(
+            "sunset / plug in",
+            "Sunset the hand-rolled logic inside PaymentService for Stripe",
+            "Plug a PayPal client into PaymentService",
+            payment_scopes(),
+        ),
+        symmetric(
+            "overhaul / enable",
+            "Overhaul PaymentService so Stripe is the only backend",
+            "Enable PayPal alongside the existing PaymentService flow",
+            payment_scopes(),
+        ),
+        symmetric(
+            "tear out / offer",
+            "Tear the legacy processor out of PaymentService and use Stripe",
+            "Offer PayPal as a second processor in PaymentService",
+            payment_scopes(),
+        ),
+        symmetric(
+            "standardize / handle",
+            "Standardize PaymentService on the Stripe integration",
+            "Handle PayPal callbacks inside PaymentService",
+            payment_scopes(),
+        ),
+        symmetric(
+            "collapse / integrate",
+            "Collapse PaymentService down to a single Stripe implementation",
+            "Integrate PayPal into PaymentService",
+            payment_scopes(),
+        ),
+    ];
+
+    // Set B: compatible work, both agents claiming the same coarse scope.
+    let set_b = vec![
+        symmetric(
+            "move loop / add metric",
+            "Move the ThumbnailCache eviction loop into a background task",
+            "Add a hit-rate metric to ThumbnailCache",
+            cache_scopes(),
+        ),
+        symmetric(
+            "drop counter / add TTL",
+            "Drop the unused debug counter from ThumbnailCache",
+            "Add TTL-based expiry to ThumbnailCache",
+            cache_scopes(),
+        ),
+        symmetric(
+            "convert logging / add warm",
+            "Convert ThumbnailCache logging to structured fields",
+            "Add a cache-warming step to ThumbnailCache",
+            cache_scopes(),
+        ),
+        symmetric(
+            "remove dead code / extend",
+            "Remove dead code left behind in ThumbnailCache",
+            "Extend ThumbnailCache to store WebP variants",
+            cache_scopes(),
+        ),
+        symmetric(
+            "rename locals / add bounds",
+            "Rename the confusing local variables inside ThumbnailCache",
+            "Add bounds checking to ThumbnailCache",
+            cache_scopes(),
+        ),
+        symmetric(
+            "delete test / add limit",
+            "Delete the flaky ThumbnailCache benchmark test",
+            "Implement a size limit for ThumbnailCache",
+            cache_scopes(),
+        ),
+        symmetric(
+            "retire flag / add AVIF",
+            "Retire the obsolete feature flag guarding ThumbnailCache",
+            "Add AVIF support to ThumbnailCache",
+            cache_scopes(),
+        ),
+    ];
+
+    // Set C: the same compatible work, but each agent claims a precise,
+    // disjoint scope. Anything firing here is reading the prose, not the claim.
+    let set_c = vec![
+        Pair {
+            label: "delete test / add limit",
+            left: "Delete the flaky ThumbnailCache benchmark test",
+            left_scopes: vec![scope("file", "tests/thumbnail_bench.rs")],
+            right: "Implement a size limit for ThumbnailCache",
+            right_scopes: vec![scope("symbol", "ThumbnailCache")],
+        },
+        Pair {
+            label: "retire flag / add AVIF",
+            left: "Retire the obsolete feature flag guarding ThumbnailCache",
+            left_scopes: vec![scope("config", "features.thumbnails_v2")],
+            right: "Add AVIF support to ThumbnailCache",
+            right_scopes: vec![scope("symbol", "ThumbnailCache")],
+        },
+    ];
+
+    let (a_high, _) = report(
+        "SET A: real conflicts, paraphrased (scopes identical)",
+        &set_a,
+    );
+    let (b_high, _) = report("SET B: compatible work, shared scope", &set_b);
+    let (c_high, _) = report("SET C: compatible work, disjoint scopes", &set_c);
+
+    println!(
+        "\n  Set A conflicts detected at HIGH: {a_high}/{}",
+        set_a.len()
+    );
+    println!("  Set B false HIGH: {b_high}/{}", set_b.len());
+    println!("  Set C false HIGH: {c_high}/{}\n", set_c.len());
+
+    assert_eq!(
+        b_high, 0,
+        "compatible work must never raise a HIGH intent conflict"
+    );
+    assert_eq!(
+        c_high, 0,
+        "compatible work with disjoint claims must never raise a HIGH intent conflict"
+    );
+    assert!(
+        a_high >= 6,
+        "paraphrase coverage regressed below the recorded floor: {a_high}/10"
+    );
+}


### PR DESCRIPTION
Recovered work that existed on two branches and was never merged.

`fix/intent-conflict-false-positives` and `protocol/declared-operations` both carried this same change, written twice by different sessions. This takes the newer of the two, cherry-picked onto current `main`.

One integration fix was needed: `tests/full_flow_probe.rs` used `register_agent(...).id`, but #10 changed that call to return a `RegisterAgentOutcome` wrapping the agent. The probe now unwraps `.agent`.

`make verify` passes. The one e2e failure seen while preparing this was `final_validation_snapshot_does_not_hold_the_coordination_write_lock` at load average 328; it passes in isolation both with and without `FOREMERGE_TEST_TIMEOUT_SCALE`, so it is the load-sensitivity #10 documented rather than a regression.