### PR TITLE
Point doctor at a command that works, and let one Codex registration serve every repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,9 @@ the scope, and check for conflicts before you start.
 ```
 
 Adjust step 4 to whatever this repository's real test command is. Step 3 asks
-the client to enable an MCP server, so it will prompt you before doing so, and
-the Codex registration is user level and points at one repository at a time.
+the client to enable an MCP server, so it will prompt you before doing so. The
+Codex registration is user level, but one registration serves every repository:
+start Codex inside the repository you want it to coordinate.
 
 ### Or do it yourself
 
@@ -171,8 +172,8 @@ Upgrading Foremerge refreshes its own unedited skill file in place, but a skill
 file you edited, or a differing Foremerge MCP entry, is never replaced unless
 you explicitly pass `--force`. `setup all` attempts every client and reports each
 result, exiting nonzero if any failed. The Codex MCP registration is user-level
-and points at one repository at a time; see
-[agent client setup](docs/agent-clients.md).
+and serves every repository, resolved from the directory Codex is started in;
+see [agent client setup](docs/agent-clients.md).
 
 `init` creates local coordination state under the repository's Git common
 directory. It does not change tracked files. The following no-worktree sessions

--- a/README.md
+++ b/README.md
@@ -166,9 +166,10 @@ worktrees, because dependency directories are usually gitignored and
 `git worktree add` will not create them.
 
 Use `setup codex`, `setup claude`, or `setup cursor` for one client. Setup
-preserves unrelated configuration (including key order in project MCP JSON) and
-refuses to replace a differing or stale skill or Foremerge MCP entry unless you
-explicitly pass `--force`. `setup all` attempts every client and reports each
+preserves unrelated configuration (including key order in project MCP JSON).
+Upgrading Foremerge refreshes its own unedited skill file in place, but a skill
+file you edited, or a differing Foremerge MCP entry, is never replaced unless
+you explicitly pass `--force`. `setup all` attempts every client and reports each
 result, exiting nonzero if any failed. The Codex MCP registration is user-level
 and points at one repository at a time; see
 [agent client setup](docs/agent-clients.md).

--- a/docs/agent-clients.md
+++ b/docs/agent-clients.md
@@ -28,11 +28,20 @@ its command resolves to an existing `foremerge` executable (including the
 portable templates shipped in a source clone) and any `--cwd` argument points
 at this repository. Setup is idempotent when installed content is current.
 
-Setup never replaces a differing skill file or `mcpServers.foremerge` entry by
-default; a stale entry (moved repository, deleted binary) is refused rather
-than reported as configured. Inspect the existing content first; use `--force`
-only when replacing it is intentional. Use `--skip-mcp` to install the skill
-without changing MCP configuration.
+Every installed skill file ends with a managed stamp naming the release that
+wrote it and a digest of the instructions above it. Upgrading Foremerge
+therefore replaces its own unedited skill file in place, with no `--force`:
+the digest proves nothing was changed after Foremerge wrote it. A file whose
+body no longer matches its own stamp was edited, and is never replaced without
+`--force`. A file already carrying this release's instructions is left exactly
+as it is, stamped or not, so a source clone's tracked skill files are not
+rewritten.
+
+Setup never replaces an edited skill file or a differing `mcpServers.foremerge`
+entry by default; a stale entry (moved repository, deleted binary) is refused
+rather than reported as configured. Inspect the existing content first; use
+`--force` only when replacing it is intentional. Use `--skip-mcp` to install
+the skill without changing MCP configuration.
 
 `setup all` attempts every requested client even when one fails: the report
 lists each client's result, failed clients carry an `error` field, and the
@@ -127,8 +136,10 @@ the optional HTTP daemon.
 
 ## Repair or remove
 
-If a diagnostic reports stale content, inspect the diff and rerun the matching
-setup command with `--force`.
+If a diagnostic reports stale content, rerun the matching setup command. The
+diagnostic's `next_step` names `--force` only when setup would otherwise refuse,
+which for a skill file means it was edited after Foremerge wrote it. Inspect the
+diff before forcing in that case.
 
 To remove an integration:
 

--- a/docs/agent-clients.md
+++ b/docs/agent-clients.md
@@ -66,13 +66,21 @@ editing that file directly. Setup reports this one out-of-repository write as
 setup still installs the repository skill and returns the exact registration
 command as its next step.
 
-Because the registration is user-global, Codex coordinates one repository at a
-time: the single `foremerge` entry bakes in the repository's `--cwd`. Running
-`foremerge setup codex` in a second repository refuses when the entry points at
-a different repository; pass `--force` to repoint Codex at the current
-repository. The report then carries an explicit warning naming the repository
-Codex now coordinates and the previous repository where `foremerge setup codex`
-must be re-run to switch back.
+That one registration serves every repository. It carries no `--cwd`: Codex
+spawns stdio MCP servers in the directory it was launched from, so the server
+resolves its repository from there, the way git resolves one from the directory
+you run it in. Running `foremerge setup codex` in a second repository is a
+no-op, and a Codex session started in any repository coordinates that
+repository.
+
+Setup replaces an earlier pinned registration, one carrying a `--cwd`, without
+`--force`: that form was written by Foremerge and pins Codex to a single
+repository. Any other `foremerge` entry, including one an operator disabled,
+is refused unless you pass `--force`.
+
+Start Codex inside a repository. Launched anywhere else the server has no
+repository to resolve and every tool call fails with `INVALID_INPUT` naming the
+directory, rather than coordinating against a store created beside it.
 
 Claude Code and Cursor use project JSON files. Foremerge merges only the
 `mcpServers.foremerge` entry and preserves other top-level keys and servers.

--- a/docs/agent-clients.md
+++ b/docs/agent-clients.md
@@ -24,9 +24,13 @@ foremerge doctor --client all
 Setup initializes Foremerge state if needed and reports every file or client
 registration it changed. New MCP entries use an absolute binary and repository
 path; the installer also accepts an existing entry that is verifiably current:
-its command resolves to an existing `foremerge` executable (including the
-portable templates shipped in a source clone) and any `--cwd` argument points
-at this repository. Setup is idempotent when installed content is current.
+its command is an absolute path to an existing `foremerge` executable and any
+`--cwd` argument points at this repository. A bare or relative command is not
+current, because the MCP client would resolve it in its own `PATH` and working
+directory rather than this process's. That includes the portable `.mcp.json`
+and `.cursor/mcp.json` templates tracked in a source clone, so running setup in
+a clone reports its MCP entry as stale and rewrites it with absolute paths under
+`--force`. Setup is idempotent when installed content is current.
 
 Every installed skill file ends with a managed stamp naming the release that
 wrote it and a digest of the instructions above it. Upgrading Foremerge

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -793,6 +793,21 @@ async fn execute(cli: Cli) -> Result<Completion> {
             }
         }
         Commands::Mcp => {
+            // Clients register one portable MCP entry and spawn it in the
+            // directory the operator is working in, so the repository is
+            // resolved here the way git resolves one: from where the process
+            // runs. Outside a repository that resolution has no answer, and
+            // continuing would create a stray store beside the spawn directory
+            // rather than coordinating anything, so fail where the operator can
+            // still read the reason.
+            if cli.database.is_none() {
+                git::discover(&cwd).with_context(|| {
+                    format!(
+                        "INVALID_INPUT: no Git repository at {}; the MCP server resolves its repository from the directory the client spawns it in, so start the client inside a repository or register it with an explicit --cwd",
+                        cwd.display()
+                    )
+                })?;
+            }
             let service = open_service(&database, &cwd)?;
             mcp::run_stdio(service).await?;
         }

--- a/src/integrations.rs
+++ b/src/integrations.rs
@@ -1195,6 +1195,46 @@ mod tests {
     }
 
     #[test]
+    fn a_cwd_with_no_value_does_not_read_as_a_pinned_registration() {
+        let temp = tempfile::tempdir().unwrap();
+        let exe = temp.path().join("foremerge");
+        fs::write(&exe, b"#!/bin/sh\n").unwrap();
+
+        // A `--cwd` carrying no value pins the entry to nothing. Reading it as
+        // Some("") would classify a malformed entry as Foremerge's own pinned
+        // form, which setup replaces without --force.
+        for empty in ["", "   "] {
+            let json = serde_json::json!({
+                "transport": {
+                    "command": exe.to_string_lossy(),
+                    "args": ["--cwd", empty, "mcp"],
+                },
+            });
+            let entry = parse_codex_entry(&json).expect("entry parses");
+            assert_eq!(
+                entry.cwd, None,
+                "an empty --cwd must read as absent: {empty:?}"
+            );
+            assert_eq!(
+                entry.registration(),
+                CodexRegistration::Current,
+                "an entry pinned to nothing is the portable form, not an upgradable one"
+            );
+        }
+
+        // A real path still reads as pinned.
+        let pinned = serde_json::json!({
+            "transport": {
+                "command": exe.to_string_lossy(),
+                "args": ["--cwd", "/some/repo", "mcp"],
+            },
+        });
+        let entry = parse_codex_entry(&pinned).expect("entry parses");
+        assert_eq!(entry.cwd.as_deref(), Some(Path::new("/some/repo")));
+        assert_eq!(entry.registration(), CodexRegistration::Upgradable);
+    }
+
+    #[test]
     fn disabled_unverifiable_or_foreign_codex_entries_need_force() {
         let temp = tempfile::tempdir().unwrap();
         let exe = temp.path().join("foremerge");

--- a/src/integrations.rs
+++ b/src/integrations.rs
@@ -374,13 +374,34 @@ fn diagnose_client(root: &Path, client: Client) -> ClientDiagnostic {
     let skill_installed = skill_bytes.is_some();
     let skill_current = skill_bytes.as_deref() == Some(SKILL_CONTENT.as_bytes());
     let mcp_path = client.mcp_path(root);
-    let (mcp_configured, mcp_probe_error) = match mcp_path.as_deref() {
-        Some(path) => (mcp_json_configured(path, root), None),
-        None => match codex_mcp_configured(root) {
-            Ok(configured) => (configured, None),
-            Err(error) => (false, Some(format!("{error:#}"))),
-        },
-    };
+    // Codex keeps its registration in user-global configuration, so a present
+    // entry pointing elsewhere needs --force and a message naming both
+    // repositories. Project JSON entries only need the generic --force step.
+    let (mcp_configured, mcp_probe_error, mcp_repoint_step, mcp_entry_stale) =
+        match mcp_path.as_deref() {
+            Some(path) => (
+                mcp_json_configured(path, root),
+                None,
+                None,
+                mcp_json_entry_stale(path, root),
+            ),
+            None => match codex_mcp_entry() {
+                Ok(Some(entry)) if entry.is_current_for(root) => (true, None, None, false),
+                Ok(Some(entry)) => (false, None, Some(codex_repoint_step(&entry, root)), false),
+                Ok(None) => (false, None, None, false),
+                Err(error) => (false, Some(format!("{error:#}")), None, false),
+            },
+        };
+    // Setup refuses to replace managed content that differs from this release,
+    // so offering a plain `setup` here would name a command that cannot
+    // succeed. Report what actually blocks it and ask for --force instead.
+    let mut blocked: Vec<&str> = Vec::new();
+    if skill_installed && !skill_current {
+        blocked.push("skill file");
+    }
+    if mcp_entry_stale {
+        blocked.push("mcpServers.foremerge entry");
+    }
     let client_available = command_available(client.executable())
         || (client == Client::Cursor && command_available("cursor"));
     let ready = client_available && skill_current && mcp_configured;
@@ -390,6 +411,10 @@ fn diagnose_client(root: &Path, client: Client) -> ClientDiagnostic {
         Some(format!(
             "Could not probe the codex CLI ({error}); check that `codex` works, then run `foremerge doctor --client codex` again."
         ))
+    } else if let Some(step) = mcp_repoint_step {
+        Some(step)
+    } else if !blocked.is_empty() {
+        Some(force_setup_step(client, &blocked))
     } else if !skill_current || !mcp_configured {
         Some(format!(
             "Run `foremerge setup {}` from this repository.",
@@ -500,10 +525,7 @@ fn configure_codex_mcp(root: &Path, foremerge_exe: &Path, force: bool) -> Result
         if !force {
             bail!(
                 "ALREADY_EXISTS: Codex MCP configuration is user-global and its `foremerge` entry currently points at {}; rerun `foremerge setup codex --force` to repoint Codex at {}",
-                entry.cwd.as_deref().map_or_else(
-                    || "a different or stale target".to_string(),
-                    |cwd| format!("repository {}", cwd.display())
-                ),
+                entry.target_description(),
                 root.display()
             );
         }
@@ -603,6 +625,16 @@ impl CodexEntry {
             Some(command) => command_resolves_to_foremerge(command),
             None => false,
         }
+    }
+
+    /// How this registration's target reads in operator-facing messages.
+    /// Shared by setup's refusal and doctor's next step so both name the same
+    /// repository instead of drifting apart.
+    fn target_description(&self) -> String {
+        self.cwd.as_deref().map_or_else(
+            || "a different or stale target".to_string(),
+            |cwd| format!("repository {}", cwd.display()),
+        )
     }
 
     fn serialized(&self) -> String {
@@ -759,6 +791,19 @@ fn find_command_object(value: &Value) -> Option<&Map<String, Value>> {
     }
 }
 
+/// The corrective step for a Codex registration that exists but does not serve
+/// `root`. Such an entry is refused by a plain `foremerge setup codex`, so the
+/// step must name `--force` and the repository Codex is currently registered
+/// for; otherwise the diagnostic sends the operator to a command that cannot
+/// succeed.
+fn codex_repoint_step(entry: &CodexEntry, root: &Path) -> String {
+    format!(
+        "Codex MCP configuration is user-global and its `foremerge` entry currently points at {}; run `foremerge setup codex --force` from this repository to repoint Codex at {}.",
+        entry.target_description(),
+        root.display()
+    )
+}
+
 /// Ok(true): a current, enabled registration exists. Ok(false): verifiably
 /// absent, stale, or disabled. Err: the codex CLI could not be probed, which
 /// callers must surface rather than treat as absence.
@@ -773,11 +818,35 @@ fn command_available(command: &str) -> bool {
 }
 
 fn mcp_json_configured(path: &Path, root: &Path) -> bool {
+    mcp_json_entry(path).is_some_and(|entry| mcp_entry_current(&entry, root))
+}
+
+/// The `mcpServers.foremerge` entry recorded in a project MCP file, if the file
+/// exists, parses, and defines one.
+fn mcp_json_entry(path: &Path) -> Option<Value> {
     fs::read(path)
         .ok()
         .and_then(|bytes| serde_json::from_slice::<Value>(&bytes).ok())
         .and_then(|value| value.get("mcpServers")?.get("foremerge").cloned())
-        .is_some_and(|entry| mcp_entry_current(&entry, root))
+}
+
+/// The corrective step when setup would refuse to replace managed content that
+/// differs from this release. Naming `--force` is what separates this from the
+/// plain step: without it the suggested command fails with ALREADY_EXISTS.
+fn force_setup_step(client: Client, blocked: &[&str]) -> String {
+    format!(
+        "Run `foremerge setup {} --force` from this repository: setup will not replace the existing {} without it.",
+        client.name(),
+        blocked.join(" and ")
+    )
+}
+
+/// True when the project MCP file already defines `mcpServers.foremerge` but
+/// the entry is not current for this repository. Setup refuses to replace such
+/// an entry without --force, so the diagnostic must ask for --force rather than
+/// a plain `setup`.
+fn mcp_json_entry_stale(path: &Path, root: &Path) -> bool {
+    mcp_json_entry(path).is_some_and(|entry| !mcp_entry_current(&entry, root))
 }
 
 /// True only for an entry that is verifiably current for this repository: its
@@ -998,6 +1067,107 @@ mod tests {
             "transport": { "command": "foremerge", "args": [] },
         });
         assert!(parse_codex_entry(&no_flag).expect("entry parses").enabled);
+    }
+
+    #[test]
+    fn codex_diagnostic_step_for_another_repository_names_force() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+        let elsewhere = PathBuf::from("/somewhere/else");
+        let entry = CodexEntry {
+            command: Some("/usr/local/bin/foremerge".to_string()),
+            cwd: Some(elsewhere.clone()),
+            enabled: true,
+        };
+        assert!(!entry.is_current_for(&root));
+
+        let step = codex_repoint_step(&entry, &root);
+        // A plain `setup codex` refuses this entry, so the diagnostic must not
+        // offer it as the next step.
+        assert!(
+            step.contains("`foremerge setup codex --force`"),
+            "step must name --force: {step}"
+        );
+        assert!(
+            step.contains(&elsewhere.display().to_string()),
+            "step must name the repository Codex currently serves: {step}"
+        );
+        assert!(
+            step.contains(&root.display().to_string()),
+            "step must name the repository being repointed to: {step}"
+        );
+    }
+
+    #[test]
+    fn codex_target_description_survives_an_unreadable_cwd() {
+        let unknown = CodexEntry {
+            command: Some("/usr/local/bin/foremerge".to_string()),
+            cwd: None,
+            enabled: true,
+        };
+        assert_eq!(
+            unknown.target_description(),
+            "a different or stale target",
+            "an entry whose cwd codex did not report still needs --force"
+        );
+    }
+
+    #[test]
+    fn stale_managed_content_asks_for_force_and_names_what_blocks_setup() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+        let path = root.join(".mcp.json");
+
+        // An absent file and a current entry must not demand --force.
+        assert!(!mcp_json_entry_stale(&path, &root));
+        let exe = root.join("foremerge");
+        fs::write(&exe, b"#!/bin/sh\n").unwrap();
+        fs::write(
+            &path,
+            serde_json::to_vec(&serde_json::json!({
+                "mcpServers": {
+                    "foremerge": {
+                        "command": exe.to_string_lossy(),
+                        "args": ["--cwd", root.to_string_lossy(), "mcp"],
+                    }
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        assert!(
+            !mcp_json_entry_stale(&path, &root),
+            "a current entry is replaced in place, so it must not demand --force"
+        );
+
+        // An entry pointing at another repository is refused without --force.
+        fs::write(
+            &path,
+            serde_json::to_vec(&serde_json::json!({
+                "mcpServers": {
+                    "foremerge": {
+                        "command": exe.to_string_lossy(),
+                        "args": ["--cwd", "/somewhere/else", "mcp"],
+                    }
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        assert!(mcp_json_entry_stale(&path, &root));
+
+        let step = force_setup_step(
+            Client::Claude,
+            &["skill file", "mcpServers.foremerge entry"],
+        );
+        assert!(
+            step.contains("`foremerge setup claude --force`"),
+            "step must name --force: {step}"
+        );
+        assert!(
+            step.contains("skill file and mcpServers.foremerge entry"),
+            "step must name every blocking artifact: {step}"
+        );
     }
 
     #[test]

--- a/src/integrations.rs
+++ b/src/integrations.rs
@@ -438,7 +438,7 @@ fn configure_client_mcp(
             if configure_mcp {
                 configure_codex_mcp(root, foremerge_exe, force)
             } else {
-                let (configured, warning) = match codex_mcp_configured(root) {
+                let (configured, warning) = match codex_mcp_configured() {
                     Ok(configured) => (configured, None),
                     Err(error) => (
                         false,
@@ -450,9 +450,8 @@ fn configure_client_mcp(
                     configured,
                     next_step: (!configured).then(|| {
                         format!(
-                            "Run `codex mcp add foremerge -- {} --cwd {} mcp` to enable Foremerge tools.",
-                            foremerge_exe.display(),
-                            root.display()
+                            "Run `codex mcp add foremerge -- {} mcp` to enable Foremerge tools.",
+                            foremerge_exe.display()
                         )
                     }),
                     warning,
@@ -496,21 +495,24 @@ fn diagnose_client(root: &Path, client: Client) -> ClientDiagnostic {
     // Codex keeps its registration in user-global configuration, so a present
     // entry pointing elsewhere needs --force and a message naming both
     // repositories. Project JSON entries only need the generic --force step.
-    let (mcp_configured, mcp_probe_error, mcp_repoint_step, mcp_entry_stale) =
-        match mcp_path.as_deref() {
-            Some(path) => (
-                mcp_json_configured(path, root),
-                None,
-                None,
-                mcp_json_entry_stale(path, root),
-            ),
-            None => match codex_mcp_entry() {
-                Ok(Some(entry)) if entry.is_current_for(root) => (true, None, None, false),
-                Ok(Some(entry)) => (false, None, Some(codex_repoint_step(&entry, root)), false),
-                Ok(None) => (false, None, None, false),
-                Err(error) => (false, Some(format!("{error:#}")), None, false),
+    let (mcp_configured, mcp_probe_error, mcp_entry_stale) = match mcp_path.as_deref() {
+        Some(path) => (
+            mcp_json_configured(path, root),
+            None,
+            mcp_json_entry_stale(path, root),
+        ),
+        None => match codex_mcp_entry() {
+            Ok(Some(entry)) => match entry.registration() {
+                CodexRegistration::Current => (true, None, false),
+                // Setup upgrades this form on its own, so a plain `setup
+                // codex` is the correct next step.
+                CodexRegistration::Upgradable => (false, None, false),
+                CodexRegistration::Foreign => (false, None, true),
             },
-        };
+            Ok(None) => (false, None, false),
+            Err(error) => (false, Some(format!("{error:#}")), false),
+        },
+    };
     // Setup refuses to replace managed content that differs from this release,
     // so offering a plain `setup` here would name a command that cannot
     // succeed. Report what actually blocks it and ask for --force instead.
@@ -519,7 +521,10 @@ fn diagnose_client(root: &Path, client: Client) -> ClientDiagnostic {
         blocked.push("skill file");
     }
     if mcp_entry_stale {
-        blocked.push("mcpServers.foremerge entry");
+        blocked.push(match client {
+            Client::Codex => "Codex MCP registration",
+            Client::Claude | Client::Cursor => "mcpServers.foremerge entry",
+        });
     }
     let client_available = command_available(client.executable())
         || (client == Client::Cursor && command_available("cursor"));
@@ -530,8 +535,6 @@ fn diagnose_client(root: &Path, client: Client) -> ClientDiagnostic {
         Some(format!(
             "Could not probe the codex CLI ({error}); check that `codex` works, then run `foremerge doctor --client codex` again."
         ))
-    } else if let Some(step) = mcp_repoint_step {
-        Some(step)
     } else if !blocked.is_empty() {
         Some(force_setup_step(client, &blocked))
     } else if !skill_current || !mcp_configured {
@@ -612,41 +615,42 @@ fn merge_mcp_config(
     write_managed(path, &encoded, true)
 }
 
-fn configure_codex_mcp(root: &Path, foremerge_exe: &Path, force: bool) -> Result<McpOutcome> {
+fn configure_codex_mcp(_root: &Path, foremerge_exe: &Path, force: bool) -> Result<McpOutcome> {
     if !command_available("codex") {
         return Ok(McpOutcome {
             install: None,
             configured: false,
             next_step: Some(format!(
-                "Run `codex mcp add foremerge -- {} --cwd {} mcp` after installing Codex CLI.",
-                foremerge_exe.display(),
-                root.display()
+                "Run `codex mcp add foremerge -- {} mcp` after installing Codex CLI.",
+                foremerge_exe.display()
             )),
             warning: None,
         });
     }
-    // A probe failure must abort configuration: treating it as "no entry"
-    // would skip the second-repository refusal below and silently repoint a
-    // registration this process could not even read.
+    // A probe failure must abort configuration: treating it as "no entry" would
+    // silently replace a registration this process could not even read.
     let existing = codex_mcp_entry()?;
     if let Some(entry) = &existing {
-        if entry.is_current_for(root) {
-            return Ok(McpOutcome {
-                install: Some(FileInstall {
-                    path: CODEX_MCP_SCOPE.to_string(),
-                    status: "unchanged".to_string(),
-                }),
-                configured: true,
-                next_step: None,
-                warning: None,
-            });
-        }
-        if !force {
-            bail!(
-                "ALREADY_EXISTS: Codex MCP configuration is user-global and its `foremerge` entry currently points at {}; rerun `foremerge setup codex --force` to repoint Codex at {}",
-                entry.target_description(),
-                root.display()
-            );
+        match entry.registration() {
+            CodexRegistration::Current => {
+                return Ok(McpOutcome {
+                    install: Some(FileInstall {
+                        path: CODEX_MCP_SCOPE.to_string(),
+                        status: "unchanged".to_string(),
+                    }),
+                    configured: true,
+                    next_step: None,
+                    warning: None,
+                });
+            }
+            // Foremerge's own pinned form. Replacing it frees Codex to serve
+            // every repository, and destroys nothing an operator wrote.
+            CodexRegistration::Upgradable => {}
+            CodexRegistration::Foreign if !force => bail!(
+                "ALREADY_EXISTS: Codex already defines a user-global `foremerge` MCP entry ({}); inspect it or rerun `foremerge setup codex --force` to replace it",
+                entry.serialized()
+            ),
+            CodexRegistration::Foreign => {}
         }
         let mut remove = Command::new("codex");
         remove.args(["mcp", "remove", "foremerge"]);
@@ -669,11 +673,11 @@ fn configure_codex_mcp(root: &Path, foremerge_exe: &Path, force: bool) -> Result
             entry.restore_command()
         )
     });
+    // No --cwd: Codex spawns stdio servers in the directory it was launched
+    // from, so one registration serves every repository.
     let mut add = Command::new("codex");
     add.args(["mcp", "add", "foremerge", "--"])
         .arg(foremerge_exe)
-        .arg("--cwd")
-        .arg(root)
         .arg("mcp");
     let output = run_bounded(add).map_err(|error| {
         let error = coded(error, "CHECK_FAILED", "run `codex mcp add foremerge`");
@@ -689,22 +693,17 @@ fn configure_codex_mcp(root: &Path, foremerge_exe: &Path, force: bool) -> Result
             removed_note.as_deref().unwrap_or("")
         );
     }
-    let warning = existing.map(|entry| {
-        let mut message = format!(
-            "Codex MCP registration is user-global: Codex now coordinates {}",
-            root.display()
-        );
-        match entry.cwd {
-            Some(previous) if !paths_match(&previous, root) => {
-                message.push_str(&format!(
-                    "; re-run `foremerge setup codex` in {} to switch back.",
-                    previous.display()
-                ));
-            }
-            _ => message.push('.'),
-        }
-        message
-    });
+    let warning = existing
+        .filter(|entry| entry.cwd.is_some())
+        .map(|entry| {
+            format!(
+                "Codex was pinned to {} and is now portable: one registration serves every repository, resolved from the directory Codex is launched in.",
+                entry
+                    .cwd
+                    .as_deref()
+                    .map_or_else(|| "one repository".to_string(), |cwd| cwd.display().to_string())
+            )
+        });
     Ok(McpOutcome {
         install: Some(FileInstall {
             path: CODEX_MCP_SCOPE.to_string(),
@@ -719,6 +718,19 @@ fn configure_codex_mcp(root: &Path, foremerge_exe: &Path, force: bool) -> Result
 /// The Codex CLI's `foremerge` MCP entry, as far as it can be recovered from
 /// `codex mcp get` output. `command` is `None` when only the plain-text form
 /// was parseable.
+/// How Codex's recorded `foremerge` registration relates to the portable one
+/// setup writes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CodexRegistration {
+    /// The portable form: resolves its repository from the spawn directory.
+    Current,
+    /// Foremerge's own earlier form, pinned to one repository with `--cwd`.
+    Upgradable,
+    /// Anything else, including a disabled or unreadable entry. Never replaced
+    /// without --force.
+    Foreign,
+}
+
 #[derive(Debug)]
 struct CodexEntry {
     enabled: bool,
@@ -727,33 +739,33 @@ struct CodexEntry {
 }
 
 impl CodexEntry {
-    fn is_current_for(&self, root: &Path) -> bool {
+    /// How this registration relates to the one setup would write.
+    ///
+    /// Codex stores MCP registrations in user-global configuration, so a
+    /// registration that names a repository can only ever serve that one.
+    /// Setup registers the portable form instead, which carries no `--cwd` and
+    /// resolves the repository from the working directory Codex spawns it in,
+    /// the way git resolves a repository from where it is run.
+    fn registration(&self) -> CodexRegistration {
         // A disabled registration does not serve tools, and an entry whose
-        // command Codex did not report cannot be verified; neither counts as
-        // current, so setup offers --force and doctor reports not configured.
+        // command Codex did not report cannot be verified. Neither is safe to
+        // replace on Foremerge's own authority.
         if !self.enabled {
-            return false;
+            return CodexRegistration::Foreign;
         }
-        let Some(cwd) = self.cwd.as_deref() else {
-            return false;
+        let Some(command) = self.command.as_deref() else {
+            return CodexRegistration::Foreign;
         };
-        if !paths_match(cwd, root) {
-            return false;
+        if !command_resolves_to_foremerge(command) {
+            return CodexRegistration::Foreign;
         }
-        match self.command.as_deref() {
-            Some(command) => command_resolves_to_foremerge(command),
-            None => false,
+        match self.cwd {
+            // The pre-portable form Foremerge itself used to write. Replacing
+            // it destroys nothing an operator authored, and leaving it in place
+            // would keep Codex pinned to one repository.
+            Some(_) => CodexRegistration::Upgradable,
+            None => CodexRegistration::Current,
         }
-    }
-
-    /// How this registration's target reads in operator-facing messages.
-    /// Shared by setup's refusal and doctor's next step so both name the same
-    /// repository instead of drifting apart.
-    fn target_description(&self) -> String {
-        self.cwd.as_deref().map_or_else(
-            || "a different or stale target".to_string(),
-            |cwd| format!("repository {}", cwd.display()),
-        )
     }
 
     fn serialized(&self) -> String {
@@ -823,7 +835,7 @@ fn codex_mcp_entry() -> Result<Option<CodexEntry>> {
             .iter()
             .position(|token| *token == "--cwd")
             .and_then(|position| tokens.get(position + 1))
-            .map(PathBuf::from);
+            .and_then(|value| non_empty_cwd(value));
         // Plain output marks disabled registrations as "name (disabled)".
         return Ok(Some(CodexEntry {
             command: None,
@@ -863,6 +875,13 @@ fn codex_mcp_entry() -> Result<Option<CodexEntry>> {
     Ok(None)
 }
 
+/// A `--cwd` carrying no value pins the registration to nothing. Reading it as
+/// a path would make a malformed entry look like Foremerge's own pinned form
+/// and so replaceable without --force, so treat it as absent instead.
+fn non_empty_cwd(value: &str) -> Option<PathBuf> {
+    (!value.trim().is_empty()).then(|| PathBuf::from(value))
+}
+
 fn parse_codex_entry(value: &Value) -> Option<CodexEntry> {
     let object = find_command_object(value)?;
     let command = object
@@ -874,7 +893,7 @@ fn parse_codex_entry(value: &Value) -> Option<CodexEntry> {
         .and_then(Value::as_array)
         .and_then(|args| {
             let position = args.iter().position(|arg| arg.as_str() == Some("--cwd"))?;
-            args.get(position + 1)?.as_str().map(PathBuf::from)
+            args.get(position + 1)?.as_str().and_then(non_empty_cwd)
         });
     Some(CodexEntry {
         command,
@@ -910,24 +929,13 @@ fn find_command_object(value: &Value) -> Option<&Map<String, Value>> {
     }
 }
 
-/// The corrective step for a Codex registration that exists but does not serve
-/// `root`. Such an entry is refused by a plain `foremerge setup codex`, so the
-/// step must name `--force` and the repository Codex is currently registered
-/// for; otherwise the diagnostic sends the operator to a command that cannot
-/// succeed.
-fn codex_repoint_step(entry: &CodexEntry, root: &Path) -> String {
-    format!(
-        "Codex MCP configuration is user-global and its `foremerge` entry currently points at {}; run `foremerge setup codex --force` from this repository to repoint Codex at {}.",
-        entry.target_description(),
-        root.display()
-    )
-}
-
 /// Ok(true): a current, enabled registration exists. Ok(false): verifiably
 /// absent, stale, or disabled. Err: the codex CLI could not be probed, which
 /// callers must surface rather than treat as absence.
-fn codex_mcp_configured(root: &Path) -> Result<bool> {
-    Ok(matches!(codex_mcp_entry()?, Some(entry) if entry.is_current_for(root)))
+fn codex_mcp_configured() -> Result<bool> {
+    Ok(
+        matches!(codex_mcp_entry()?, Some(entry) if entry.registration() == CodexRegistration::Current),
+    )
 }
 
 fn command_available(command: &str) -> bool {
@@ -1160,27 +1168,61 @@ mod tests {
     }
 
     #[test]
-    fn disabled_or_unverifiable_codex_entries_are_not_current() {
-        let temp = tempfile::tempdir().unwrap();
-        let root = temp.path().canonicalize().unwrap();
-        let disabled = serde_json::json!({
+    fn a_portable_codex_entry_is_current_and_a_pinned_one_upgrades() {
+        // The form setup writes: no --cwd, so it serves whichever repository
+        // Codex is launched in.
+        let portable = serde_json::json!({
             "name": "foremerge",
-            "enabled": false,
-            "transport": {
-                "command": "/usr/local/bin/foremerge",
-                "args": ["--cwd", root.to_string_lossy(), "mcp"],
-            },
+            "enabled": true,
+            "transport": { "command": "/usr/local/bin/foremerge", "args": ["mcp"] },
         });
-        let entry = parse_codex_entry(&disabled).expect("entry parses");
-        assert!(!entry.enabled);
-        assert!(!entry.is_current_for(&root));
+        // command_resolves_to_foremerge requires the binary to exist, so point
+        // at one that does.
+        let temp = tempfile::tempdir().unwrap();
+        let exe = temp.path().join("foremerge");
+        fs::write(&exe, b"#!/bin/sh\n").unwrap();
+        let mut entry = parse_codex_entry(&portable).expect("entry parses");
+        entry.command = Some(exe.to_string_lossy().into_owned());
+        assert_eq!(entry.registration(), CodexRegistration::Current);
 
-        let unverifiable = CodexEntry {
-            command: None,
-            cwd: Some(root.clone()),
+        // Foremerge's earlier pinned form upgrades without --force.
+        let pinned = CodexEntry {
+            command: Some(exe.to_string_lossy().into_owned()),
+            cwd: Some(PathBuf::from("/somewhere/else")),
             enabled: true,
         };
-        assert!(!unverifiable.is_current_for(&root));
+        assert_eq!(pinned.registration(), CodexRegistration::Upgradable);
+    }
+
+    #[test]
+    fn disabled_unverifiable_or_foreign_codex_entries_need_force() {
+        let temp = tempfile::tempdir().unwrap();
+        let exe = temp.path().join("foremerge");
+        fs::write(&exe, b"#!/bin/sh\n").unwrap();
+
+        // A registration the operator disabled must not be silently re-added.
+        let disabled = CodexEntry {
+            command: Some(exe.to_string_lossy().into_owned()),
+            cwd: None,
+            enabled: false,
+        };
+        assert_eq!(disabled.registration(), CodexRegistration::Foreign);
+
+        // An entry whose command Codex did not report cannot be verified.
+        let unverifiable = CodexEntry {
+            command: None,
+            cwd: None,
+            enabled: true,
+        };
+        assert_eq!(unverifiable.registration(), CodexRegistration::Foreign);
+
+        // Someone else's `foremerge` entry pointing at a different program.
+        let foreign = CodexEntry {
+            command: Some("/usr/bin/env".to_string()),
+            cwd: None,
+            enabled: true,
+        };
+        assert_eq!(foreign.registration(), CodexRegistration::Foreign);
 
         let no_flag = serde_json::json!({
             "transport": { "command": "foremerge", "args": [] },
@@ -1189,45 +1231,15 @@ mod tests {
     }
 
     #[test]
-    fn codex_diagnostic_step_for_another_repository_names_force() {
-        let temp = tempfile::tempdir().unwrap();
-        let root = temp.path().canonicalize().unwrap();
-        let elsewhere = PathBuf::from("/somewhere/else");
-        let entry = CodexEntry {
-            command: Some("/usr/local/bin/foremerge".to_string()),
-            cwd: Some(elsewhere.clone()),
-            enabled: true,
-        };
-        assert!(!entry.is_current_for(&root));
-
-        let step = codex_repoint_step(&entry, &root);
-        // A plain `setup codex` refuses this entry, so the diagnostic must not
-        // offer it as the next step.
+    fn a_foreign_codex_registration_is_reported_as_needing_force() {
+        let step = force_setup_step(Client::Codex, &["Codex MCP registration"]);
         assert!(
             step.contains("`foremerge setup codex --force`"),
             "step must name --force: {step}"
         );
         assert!(
-            step.contains(&elsewhere.display().to_string()),
-            "step must name the repository Codex currently serves: {step}"
-        );
-        assert!(
-            step.contains(&root.display().to_string()),
-            "step must name the repository being repointed to: {step}"
-        );
-    }
-
-    #[test]
-    fn codex_target_description_survives_an_unreadable_cwd() {
-        let unknown = CodexEntry {
-            command: Some("/usr/local/bin/foremerge".to_string()),
-            cwd: None,
-            enabled: true,
-        };
-        assert_eq!(
-            unknown.target_description(),
-            "a different or stale target",
-            "an entry whose cwd codex did not report still needs --force"
+            step.contains("Codex MCP registration"),
+            "step must name the Codex registration, not a project JSON entry: {step}"
         );
     }
 

--- a/src/integrations.rs
+++ b/src/integrations.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
+use sha2::{Digest, Sha256};
 use std::fs::{self, OpenOptions};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
@@ -168,6 +169,100 @@ fn is_error_code(candidate: &str) -> bool {
 
 pub const SKILL_CONTENT: &str = include_str!("../.codex/skills/foremerge/SKILL.md");
 
+/// Marker Foremerge appends to every skill file it installs, naming the release
+/// that produced the body and a digest of that body.
+///
+/// The digest is what lets a later release tell a file this installer wrote
+/// from one an operator edited. Foremerge's own unedited file may be upgraded
+/// in place, because replacing it destroys nothing; an edited file still
+/// requires --force.
+const SKILL_STAMP_PREFIX: &str = "<!-- foremerge:managed ";
+const SKILL_STAMP_SUFFIX: &str = "-->";
+
+/// How an installed skill file relates to the one this release would write.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SkillState {
+    /// Already carries this release's instructions, stamped or not.
+    Current,
+    /// Foremerge's own file, untouched since it was written, from a different
+    /// release. Upgrading it is not an overwrite of anyone's work.
+    Replaceable,
+    /// Edited after Foremerge wrote it. Replacing it needs --force.
+    Edited,
+}
+
+/// The skill text without a trailing managed stamp. Both the embedded copy and
+/// on-disk files are canonicalized through this, so a stamp can never nest
+/// inside the body it describes.
+fn skill_body(content: &str) -> &str {
+    let trimmed = content.trim_end_matches('\n');
+    match trimmed.rfind('\n') {
+        Some(cut) if is_skill_stamp(&trimmed[cut + 1..]) => &content[..=cut],
+        None if is_skill_stamp(trimmed) => "",
+        _ => content,
+    }
+}
+
+fn is_skill_stamp(line: &str) -> bool {
+    line.starts_with(SKILL_STAMP_PREFIX) && line.ends_with(SKILL_STAMP_SUFFIX)
+}
+
+fn skill_digest(body: &str) -> String {
+    format!("{:x}", Sha256::digest(body.as_bytes()))
+}
+
+/// The digest a file's own stamp records, if it carries a well-formed one.
+fn skill_stamp_digest(content: &str) -> Option<&str> {
+    let trimmed = content.trim_end_matches('\n');
+    let line = trimmed.rsplit('\n').next()?;
+    if !is_skill_stamp(line) {
+        return None;
+    }
+    line.split_whitespace()
+        .find_map(|token| token.strip_prefix("sha256="))
+}
+
+/// The exact bytes setup installs: this release's body plus its stamp.
+fn desired_skill() -> String {
+    let body = skill_body(SKILL_CONTENT);
+    let mut content = String::with_capacity(body.len() + 96);
+    content.push_str(body);
+    if !content.ends_with('\n') {
+        content.push('\n');
+    }
+    content.push_str(SKILL_STAMP_PREFIX);
+    content.push_str("version=");
+    content.push_str(env!("CARGO_PKG_VERSION"));
+    content.push_str(" sha256=");
+    content.push_str(&skill_digest(body));
+    content.push(' ');
+    content.push_str(SKILL_STAMP_SUFFIX);
+    content.push('\n');
+    content
+}
+
+fn skill_state(existing: &str) -> SkillState {
+    let body = skill_body(existing);
+    if body == skill_body(SKILL_CONTENT) {
+        // Same instructions this release ships. Nothing to rewrite, even when
+        // the file predates stamping and so carries no marker of its own.
+        return SkillState::Current;
+    }
+    match skill_stamp_digest(existing) {
+        // A stamp still matching its own body proves nothing was edited after
+        // Foremerge wrote the file, so this release may upgrade it in place.
+        Some(recorded) if recorded == skill_digest(body) => SkillState::Replaceable,
+        Some(_) => SkillState::Edited,
+        // Releases before stamping left no marker, so an unstamped file is
+        // treated as Foremerge's own and upgrading off it does not demand
+        // --force. The cost is that deleting the stamp from an edited file
+        // also forfeits its protection; that is deliberate while the
+        // pre-stamp installed base still exists, and should tighten to
+        // SkillState::Edited once it does not.
+        None => SkillState::Replaceable,
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Client {
     Codex,
@@ -290,7 +385,27 @@ fn install_client(
         warning: None,
         error: None,
     };
-    match write_managed(&skill_path, SKILL_CONTENT.as_bytes(), force) {
+    let state = fs::read_to_string(&skill_path)
+        .ok()
+        .as_deref()
+        .map(skill_state);
+    let skill = match state {
+        // Already this release's instructions. Leave the file exactly as it is,
+        // so a source clone's tracked skill files are never rewritten just to
+        // gain a stamp.
+        Some(SkillState::Current) => Ok(FileInstall {
+            path: skill_path.to_string_lossy().into_owned(),
+            status: "unchanged".to_string(),
+        }),
+        // Upgrading Foremerge's own unedited file overwrites nothing the
+        // operator wrote, so it does not require --force.
+        state => write_managed(
+            &skill_path,
+            desired_skill().as_bytes(),
+            force || state == Some(SkillState::Replaceable),
+        ),
+    };
+    match skill {
         Ok(skill) => report.skill = skill,
         Err(error) => {
             report.error = Some(format!("{error:#}"));
@@ -370,9 +485,13 @@ fn configure_client_mcp(
 
 fn diagnose_client(root: &Path, client: Client) -> ClientDiagnostic {
     let skill_path = client.skill_path(root);
-    let skill_bytes = fs::read(&skill_path).ok();
-    let skill_installed = skill_bytes.is_some();
-    let skill_current = skill_bytes.as_deref() == Some(SKILL_CONTENT.as_bytes());
+    let skill_installed = skill_path.is_file();
+    // Unreadable or non-UTF-8 content is never Foremerge's own file, so it is
+    // treated as edited and kept behind --force.
+    let skill_state = skill_installed
+        .then(|| fs::read_to_string(&skill_path).ok())
+        .map(|text| text.as_deref().map_or(SkillState::Edited, skill_state));
+    let skill_current = skill_state == Some(SkillState::Current);
     let mcp_path = client.mcp_path(root);
     // Codex keeps its registration in user-global configuration, so a present
     // entry pointing elsewhere needs --force and a message naming both
@@ -396,7 +515,7 @@ fn diagnose_client(root: &Path, client: Client) -> ClientDiagnostic {
     // so offering a plain `setup` here would name a command that cannot
     // succeed. Report what actually blocks it and ask for --force instead.
     let mut blocked: Vec<&str> = Vec::new();
-    if skill_installed && !skill_current {
+    if skill_state == Some(SkillState::Edited) {
         blocked.push("skill file");
     }
     if mcp_entry_stale {
@@ -969,8 +1088,8 @@ mod tests {
         assert_eq!(reports.len(), 2);
         assert!(reports.iter().all(|report| report.error.is_none()));
         assert_eq!(
-            fs::read(temp.path().join(".claude/skills/foremerge/SKILL.md")).unwrap(),
-            SKILL_CONTENT.as_bytes()
+            fs::read_to_string(temp.path().join(".claude/skills/foremerge/SKILL.md")).unwrap(),
+            desired_skill()
         );
         let cursor: Value = serde_json::from_slice(&fs::read(cursor_config).unwrap()).unwrap();
         assert_eq!(cursor["custom"], true);
@@ -1171,6 +1290,129 @@ mod tests {
     }
 
     #[test]
+    fn installed_skill_carries_a_stamp_over_this_release_body() {
+        let installed = desired_skill();
+        assert_eq!(
+            skill_body(&installed),
+            skill_body(SKILL_CONTENT),
+            "stamping must not alter the instructions themselves"
+        );
+        assert_eq!(
+            skill_stamp_digest(&installed),
+            Some(skill_digest(skill_body(SKILL_CONTENT)).as_str()),
+            "the stamp must record the digest of the body it follows"
+        );
+        assert!(installed.contains(env!("CARGO_PKG_VERSION")));
+        assert_eq!(
+            skill_state(&installed),
+            SkillState::Current,
+            "the bytes setup writes must read back as current"
+        );
+        // Stamping is a fixed point. If a source clone's tracked file ever ends
+        // up stamped, canonicalizing it must strip that stamp rather than nest
+        // a second one inside the body.
+        let body = skill_body(&installed);
+        let restamped = format!(
+            "{body}{SKILL_STAMP_PREFIX}version=9.9.9 sha256={} {SKILL_STAMP_SUFFIX}\n",
+            skill_digest(body)
+        );
+        assert_eq!(skill_body(&restamped), skill_body(SKILL_CONTENT));
+    }
+
+    #[test]
+    fn an_unedited_older_skill_upgrades_without_force() {
+        let body = "# Foremerge\n\nOld instructions from an earlier release.\n";
+        let stamped = format!(
+            "{body}{SKILL_STAMP_PREFIX}version=0.0.1 sha256={} {SKILL_STAMP_SUFFIX}\n",
+            skill_digest(body)
+        );
+        assert_eq!(skill_state(&stamped), SkillState::Replaceable);
+
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join(".claude/skills/foremerge/SKILL.md");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, &stamped).unwrap();
+        let reports = install(
+            temp.path(),
+            &[Client::Claude],
+            Path::new("/usr/local/bin/foremerge"),
+            false,
+            false,
+        );
+        assert!(
+            reports[0].error.is_none(),
+            "an unedited older file must upgrade without --force: {:?}",
+            reports[0].error
+        );
+        assert_eq!(fs::read_to_string(&path).unwrap(), desired_skill());
+    }
+
+    #[test]
+    fn an_edited_skill_still_requires_force() {
+        let body = "# Foremerge\n\nOld instructions from an earlier release.\n";
+        let edited = format!(
+            "{body}A line the operator added.\n{SKILL_STAMP_PREFIX}version=0.0.1 sha256={} {SKILL_STAMP_SUFFIX}\n",
+            skill_digest(body)
+        );
+        assert_eq!(
+            skill_state(&edited),
+            SkillState::Edited,
+            "a body that no longer matches its own stamp was edited"
+        );
+
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join(".claude/skills/foremerge/SKILL.md");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, &edited).unwrap();
+        let reports = install(
+            temp.path(),
+            &[Client::Claude],
+            Path::new("/usr/local/bin/foremerge"),
+            false,
+            false,
+        );
+        assert!(
+            reports[0]
+                .error
+                .as_deref()
+                .is_some_and(|error| error.starts_with("ALREADY_EXISTS:")),
+            "edited content must stay behind --force: {:?}",
+            reports[0].error
+        );
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            edited,
+            "the operator's file must be left byte-for-byte intact"
+        );
+    }
+
+    #[test]
+    fn an_unstamped_body_matching_this_release_is_left_alone() {
+        // A source clone's tracked skill files carry no stamp. Setup must
+        // recognize them as current rather than rewriting tracked content.
+        assert_eq!(skill_state(SKILL_CONTENT), SkillState::Current);
+
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join(".claude/skills/foremerge/SKILL.md");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, SKILL_CONTENT).unwrap();
+        let reports = install(
+            temp.path(),
+            &[Client::Claude],
+            Path::new("/usr/local/bin/foremerge"),
+            false,
+            false,
+        );
+        assert!(reports[0].error.is_none());
+        assert_eq!(reports[0].skill.status, "unchanged");
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            SKILL_CONTENT,
+            "an unstamped current body must not be rewritten"
+        );
+    }
+
+    #[test]
     fn coded_preserves_typed_error_codes_through_context() {
         let wrapped = coded(
             anyhow::anyhow!("RESOURCE_LIMIT: codex did not finish within 10 seconds"),
@@ -1190,33 +1432,28 @@ mod tests {
     }
 
     #[test]
-    fn skill_overwrite_requires_force() {
+    fn an_unstamped_custom_skill_is_replaced_during_the_transition() {
+        // Foremerge cannot tell a hand-written unstamped file from one an
+        // earlier, pre-stamp release installed: neither carries provenance.
+        // While the pre-stamp installed base exists, such files are replaced
+        // so upgrading does not demand --force. Once every installed file
+        // carries a stamp this should tighten to SkillState::Edited, and this
+        // test should assert refusal again. Files that DO carry a stamp are
+        // already protected; see an_edited_skill_still_requires_force.
         let temp = tempfile::tempdir().unwrap();
         let path = temp.path().join(".claude/skills/foremerge/SKILL.md");
         fs::create_dir_all(path.parent().unwrap()).unwrap();
         fs::write(&path, "custom instructions").unwrap();
-        let refused = install(
+        assert_eq!(skill_state("custom instructions"), SkillState::Replaceable);
+        let reports = install(
             temp.path(),
             &[Client::Claude],
             Path::new("foremerge"),
             false,
             false,
         );
-        assert!(
-            refused[0]
-                .error
-                .as_deref()
-                .is_some_and(|error| error.starts_with("ALREADY_EXISTS"))
-        );
-        assert_eq!(refused[0].skill.status, "failed");
-        let forced = install(
-            temp.path(),
-            &[Client::Claude],
-            Path::new("foremerge"),
-            true,
-            false,
-        );
-        assert!(forced[0].error.is_none());
-        assert_eq!(fs::read(path).unwrap(), SKILL_CONTENT.as_bytes());
+        assert!(reports[0].error.is_none());
+        assert_eq!(reports[0].skill.status, "written");
+        assert_eq!(fs::read_to_string(&path).unwrap(), desired_skill());
     }
 }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -1508,14 +1508,25 @@ fn setup_installs_native_claude_and_cursor_integrations_and_named_checks() {
         Path::new(env!("CARGO_MANIFEST_DIR")).join(".codex/skills/foremerge/SKILL.md"),
     )
     .expect("read canonical skill");
-    assert_eq!(
-        fs::read_to_string(repo.root.join(".claude/skills/foremerge/SKILL.md")).unwrap(),
-        canonical_skill
-    );
-    assert_eq!(
-        fs::read_to_string(repo.root.join(".cursor/skills/foremerge/SKILL.md")).unwrap(),
-        canonical_skill
-    );
+    for client in [".claude", ".cursor"] {
+        let installed =
+            fs::read_to_string(repo.root.join(client).join("skills/foremerge/SKILL.md")).unwrap();
+        // Installed files carry a managed stamp over the canonical body, which
+        // is what lets a later release upgrade its own unedited file in place.
+        assert!(
+            installed.starts_with(&canonical_skill),
+            "{client}: installed skill must preserve the canonical instructions"
+        );
+        let stamp = installed[canonical_skill.len()..].trim();
+        assert!(
+            stamp.starts_with("<!-- foremerge:managed ") && stamp.ends_with("-->"),
+            "{client}: installed skill must end with a managed stamp, got {stamp:?}"
+        );
+        assert!(
+            stamp.contains("sha256="),
+            "{client}: stamp must record the body digest, got {stamp:?}"
+        );
+    }
     for config in [
         repo.root.join(".mcp.json"),
         repo.root.join(".cursor/mcp.json"),

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -3658,9 +3658,11 @@ case "$1" in
         shift 3
         if [ "$1" = "--" ]; then shift; fi
         exe="$1"
-        cwd=""
-        if [ "$2" = "--cwd" ]; then cwd="$3"; fi
-        printf '{"command":"%s","args":["--cwd","%s","mcp"]}\n' "$exe" "$cwd" > "$CODEX_STUB_STATE"
+        if [ "$2" = "--cwd" ]; then
+          printf '{"command":"%s","args":["--cwd","%s","mcp"]}\n' "$exe" "$3" > "$CODEX_STUB_STATE"
+        else
+          printf '{"command":"%s","args":["mcp"]}\n' "$exe" > "$CODEX_STUB_STATE"
+        fi
         exit 0
         ;;
       remove)
@@ -3757,15 +3759,16 @@ fn setup_codex_registers_the_global_mcp_entry_and_is_idempotent() {
     assert_eq!(client["error"], Value::Null);
     assert_eq!(client["warning"], Value::Null);
 
-    let canonical_root = repo.root.canonicalize().expect("canonicalize repo root");
     let log = stub.log_contents();
     let add_line = log
         .lines()
         .find(|line| line.starts_with("mcp add foremerge"))
         .expect("codex mcp add was invoked");
+    // The registration carries no --cwd: Codex spawns the server in the
+    // directory it was launched from, so one entry serves every repository.
     assert!(
-        add_line.ends_with(&format!("--cwd {} mcp", canonical_root.display())),
-        "unexpected add argv: {add_line}"
+        add_line.ends_with(" mcp") && !add_line.contains("--cwd"),
+        "the Codex registration must be portable, got: {add_line}"
     );
 
     let again = stub.run_success(&repo.root, ["setup", "codex"]);
@@ -3782,57 +3785,128 @@ fn setup_codex_registers_the_global_mcp_entry_and_is_idempotent() {
     assert_eq!(doctor["data"]["clients"][0]["mcp_configured"], true);
 }
 
+#[test]
+fn mcp_outside_a_repository_fails_instead_of_creating_a_stray_store() {
+    // The portable registration resolves its repository from the directory the
+    // client spawns the server in. Outside a repository there is no answer, and
+    // silently coordinating against a store created beside the spawn directory
+    // would be worse than refusing.
+    let temp = tempfile::tempdir().expect("temp dir");
+    let outside = temp.path().canonicalize().expect("canonicalize temp dir");
+    let output = Command::new(foremerge_bin())
+        .arg("--json")
+        .arg("--cwd")
+        .arg(&outside)
+        .arg("mcp")
+        .output()
+        .expect("run foremerge mcp");
+    assert!(
+        !output.status.success(),
+        "mcp must refuse outside a repository"
+    );
+    // The diagnosis goes to stderr: anything written to stdout would corrupt
+    // the JSON-RPC stream the client is reading.
+    assert!(
+        output.stdout.is_empty(),
+        "mcp must not write to stdout before the stream is usable: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let message = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        message.contains("INVALID_INPUT"),
+        "the refusal must carry a typed code: {message}"
+    );
+    assert!(
+        message.contains(&outside.display().to_string()),
+        "the error must name the directory it was spawned in: {message}"
+    );
+    assert!(
+        !outside.join(".foremerge").exists(),
+        "refusing must not leave a stray store behind"
+    );
+}
+
 #[cfg(unix)]
 #[test]
-fn setup_codex_refuses_to_hijack_another_repositorys_entry_without_force() {
+fn setup_codex_in_a_second_repository_is_a_no_op() {
     let repo_a = create_repo();
     let repo_b = create_repo();
     let stub = CodexStub::create(repo_a.temp.path());
     stub.run_success(&repo_a.root, ["setup", "codex"]);
-    let canonical_a = repo_a.root.canonicalize().expect("canonicalize repo A");
-    let canonical_b = repo_b.root.canonicalize().expect("canonicalize repo B");
 
-    let refusal = stub.run_failure(&repo_b.root, ["setup", "codex"]);
+    // The registration carries no repository, so it already serves repo B.
+    let second = stub.run_success(&repo_b.root, ["setup", "codex"]);
+    let client = &second["data"]["clients"][0];
+    assert_eq!(client["mcp"]["status"], "unchanged");
+    assert_eq!(client["mcp_configured"], true);
+    assert_eq!(client["error"], Value::Null);
+    assert_eq!(client["warning"], Value::Null);
+
+    let adds = stub
+        .log_contents()
+        .lines()
+        .filter(|line| line.starts_with("mcp add"))
+        .count();
+    assert_eq!(
+        adds, 1,
+        "a second repository must not re-register the entry"
+    );
+
+    // Both repositories report the same registration as ready.
+    for root in [&repo_a.root, &repo_b.root] {
+        let doctor = stub.run_success(root, ["doctor", "--client", "codex"]);
+        assert_eq!(doctor["data"]["clients"][0]["mcp_configured"], true);
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn setup_codex_upgrades_a_pinned_entry_but_refuses_a_foreign_one() {
+    let repo = create_repo();
+    let stub = CodexStub::create(repo.temp.path());
+    let canonical = repo.root.canonicalize().expect("canonicalize repo");
+
+    // Foremerge's own earlier form, pinned to one repository, upgrades without
+    // --force: replacing it destroys nothing an operator authored.
+    let exe = foremerge_bin();
+    fs::write(
+        &stub.state,
+        format!(
+            "{{\"command\":\"{}\",\"args\":[\"--cwd\",\"{}\",\"mcp\"]}}\n",
+            exe.display(),
+            canonical.display()
+        ),
+    )
+    .expect("seed pinned registration");
+    let upgraded = stub.run_success(&repo.root, ["setup", "codex"]);
+    let client = &upgraded["data"]["clients"][0];
+    assert_eq!(client["mcp"]["status"], "written");
+    let warning = client["warning"].as_str().expect("upgrade warning");
+    assert!(
+        warning.contains(&canonical.display().to_string()) && warning.contains("portable"),
+        "the warning must say the pinned registration became portable: {warning}"
+    );
+
+    // Someone else's `foremerge` entry is not Foremerge's to replace.
+    fs::write(
+        &stub.state,
+        "{\"command\":\"/usr/bin/env\",\"args\":[\"mcp\"]}\n",
+    )
+    .expect("seed foreign registration");
+    let refusal = stub.run_failure(&repo.root, ["setup", "codex"]);
     assert_eq!(refusal["error"]["code"], "ALREADY_EXISTS");
     let message = refusal["error"]["message"].as_str().expect("error message");
-    assert!(message.contains("user-global"), "{message}");
     assert!(
-        message.contains(&canonical_a.display().to_string()),
-        "refusal must name the other repository: {message}"
-    );
-    let client = &refusal["data"]["clients"][0];
-    assert_eq!(client["client"], "codex");
-    assert!(
-        client["error"]
-            .as_str()
-            .is_some_and(|error| error.contains("user-global")),
-        "per-client report must carry the error: {client}"
+        message.contains("/usr/bin/env"),
+        "the refusal must name the entry it will not replace: {message}"
     );
 
-    let forced = stub.run_success(&repo_b.root, ["setup", "codex", "--force"]);
-    let client = &forced["data"]["clients"][0];
-    assert_eq!(client["mcp"]["status"], "written");
-    let warning = client["warning"].as_str().expect("repoint warning");
-    assert!(
-        warning.contains(&canonical_b.display().to_string()),
-        "warning must name the repository Codex now coordinates: {warning}"
-    );
-    assert!(
-        warning.contains(&canonical_a.display().to_string()) && warning.contains("switch back"),
-        "warning must explain how to switch back: {warning}"
-    );
+    let forced = stub.run_success(&repo.root, ["setup", "codex", "--force"]);
+    assert_eq!(forced["data"]["clients"][0]["mcp"]["status"], "written");
     let log = stub.log_contents();
     assert!(
         log.lines().any(|line| line == "mcp remove foremerge"),
-        "force repoint must remove the previous entry: {log}"
-    );
-    let last_add = log
-        .lines()
-        .rfind(|line| line.starts_with("mcp add"))
-        .expect("codex mcp add was invoked");
-    assert!(
-        last_add.contains(&canonical_b.display().to_string()),
-        "repointed entry must target repo B: {last_add}"
+        "forcing over a foreign entry must remove it first: {log}"
     );
 }
 
@@ -3909,15 +3983,26 @@ fn setup_codex_aborts_when_the_probe_fails_instead_of_silently_adding() {
 
 #[cfg(unix)]
 #[test]
-fn setup_codex_forced_repoint_discloses_a_removed_registration_when_add_fails() {
-    let repo_a = create_repo();
-    let repo_b = create_repo();
-    let stub = CodexStub::create(repo_a.temp.path());
-    stub.run_success(&repo_a.root, ["setup", "codex"]);
-    let canonical_a = repo_a.root.canonicalize().expect("canonicalize repo A");
+fn setup_codex_discloses_a_removed_registration_when_the_replacement_add_fails() {
+    let repo = create_repo();
+    let stub = CodexStub::create(repo.temp.path());
+    let canonical = repo.root.canonicalize().expect("canonicalize repo");
+
+    // A pinned registration is replaced by the portable one. The Codex CLI has
+    // no atomic replace, so if the add fails the previous entry is already gone
+    // and the error must say so.
+    fs::write(
+        &stub.state,
+        format!(
+            "{{\"command\":\"{}\",\"args\":[\"--cwd\",\"{}\",\"mcp\"]}}\n",
+            foremerge_bin().display(),
+            canonical.display()
+        ),
+    )
+    .expect("seed pinned registration");
 
     let output = {
-        let mut command = stub.command(&repo_b.root, ["setup", "codex", "--force"]);
+        let mut command = stub.command(&repo.root, ["setup", "codex"]);
         command.env("CODEX_STUB_FAIL_MCP_ADD", "1");
         command.output().expect("run foremerge")
     };
@@ -3934,7 +4019,7 @@ fn setup_codex_forced_repoint_discloses_a_removed_registration_when_add_fails() 
         "the error must disclose the destroyed registration: {message}"
     );
     assert!(
-        message.contains(&canonical_a.display().to_string()),
+        message.contains(&canonical.display().to_string()),
         "the error must name the removed registration's repository: {message}"
     );
     assert!(


### PR DESCRIPTION
Five commits that had been sitting unmerged on a local-only branch with no PR. Rebased onto current `main` and verified.

The substance is unchanged from how it was written. One mechanical port was required: the commit that guards `foremerge mcp` outside a Git repository added its check to `src/main.rs`, which is now a thin wrapper over `foremerge::cli::run`, so the guard moved to `src/cli.rs` where the command actually dispatches.

Contents:

- `doctor` suggests a next step that can succeed rather than one that cannot
- Foremerge's own skill file upgrades without `--force`
- `setup` documents which MCP commands it accepts as current
- Codex registers one portable entry with no `--cwd`, so a single registration serves every repository instead of pinning Codex to one at a time
- A `--cwd` carrying no value reads as absent, so a malformed entry is not mistaken for Foremerge's own

`make verify` passes: 146 tests across the lib, e2e, and probe suites.