### PR TITLE
Seed the benchmark harness with the scope shape intents actually store

### DIFF
--- a/examples/query_benchmark.rs
+++ b/examples/query_benchmark.rs
@@ -3,7 +3,7 @@
 //! Run an optimized build for meaningful timings:
 //! `cargo run --release --example query_benchmark -- 500 5000 20000`.
 
-use foremerge::model::{Scope, WorkQuery};
+use foremerge::model::{Operation, Scope, ScopeClaim, WorkQuery};
 use foremerge::{Foremerge, Store};
 use rusqlite::{Connection, params};
 use serde_json::json;
@@ -124,7 +124,15 @@ fn seed(database: &Path, size: usize) -> anyhow::Result<()> {
             } else {
                 format!("Unrelated{index}")
             };
-            let scopes_json = serde_json::to_string(&[Scope::new("symbol", &scope_key)])?;
+            // Intents store `ScopeClaim`, not bare `Scope`. Seeding the old shape
+            // made every read of this fixture fail on the missing operation.
+            // `modify`, inferred, matches what `intent_scopes` defaults to for
+            // rows that predate declared operations.
+            let scopes_json = serde_json::to_string(&[ScopeClaim {
+                scope: Scope::new("symbol", &scope_key),
+                operation: Operation::Modify,
+                inferred: true,
+            }])?;
             tasks.execute(params![
                 task_id,
                 format!("task-key-{index}"),


### PR DESCRIPTION
Fixes red `main`. CI's stable job runs `cargo run --example query_benchmark -- 200`, which fails with `missing field `operation``.

Declared operations changed intents from storing `Scope` to `ScopeClaim`. Real stores are fine: schema 6 migrates them and `intent_scopes` defaults `operation`/`operation_inferred`. This harness seeds rows through raw SQL rather than the service, so it kept writing the old shape and then failed to read its own fixture.

It now seeds `modify`, inferred, matching what the `intent_scopes` defaults record for pre-declaration rows.

**Gate gap worth noting:** `make verify` and `make msrv` both pass on the broken commit, because neither runs the examples. Adding the example smoke test to `make verify` would close it, and I have not done that here to keep this fix minimal.